### PR TITLE
Fix type casting for scrollable containers

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeView.kt
@@ -61,7 +61,7 @@ fun HomeView(
 ) {
     val listState = rememberLazyListState()
     VerticallyScrollableContainer(
-        scrollState = listState,
+        scrollState = listState as ScrollState,
     ) {
         Box(
             modifier = modifier.padding(16.dp).fillMaxSize(), contentAlignment = Alignment.Center

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
@@ -2,6 +2,7 @@ package io.github.kdroidfilter.seforimapp.features.bookcontent.ui.panels.bookcon
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -202,7 +203,7 @@ private fun CommentatorsList(
 
         Row(modifier = Modifier.fillMaxSize().padding(horizontal = 4.dp)) {
             VerticallyScrollableContainer(
-                scrollState = listState,
+                scrollState = listState as ScrollState,
             ) {
                 LazyColumn(
                     state = listState,

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/booktoc/BookTocView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/booktoc/BookTocView.kt
@@ -2,6 +2,7 @@ package io.github.kdroidfilter.seforimapp.features.bookcontent.ui.panels.booktoc
 
 import androidx.compose.foundation.VerticalScrollbar
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -87,7 +88,7 @@ fun BookTocView(
 
     Box(modifier = modifier.fillMaxSize().padding(bottom = 8.dp)) {
         VerticallyScrollableContainer(
-            scrollState = listState,
+            scrollState = listState as ScrollableState,
         ) {
             LazyColumn(
                 state = listState,

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/categorytree/CategoryBookTreeView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/categorytree/CategoryBookTreeView.kt
@@ -2,6 +2,7 @@ package io.github.kdroidfilter.seforimapp.features.bookcontent.ui.panels.categor
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -113,7 +114,7 @@ fun CategoryBookTreeView(
      * -------------------------------------------------------------------- */
     Box(modifier = modifier.fillMaxSize().padding(bottom = 8.dp)) {
         VerticallyScrollableContainer(
-            scrollState = listState,
+            scrollState = listState as ScrollableState,
         ) {
             LazyColumn(
                 state = listState,


### PR DESCRIPTION
### Description

This pull request addresses issues related to type mismatch warnings in scrollable container components. 

- `scrollState` is now explicitly cast to `ScrollableState` or `ScrollState` as appropriate in `VerticallyScrollableContainer`.
- Changes applied across multiple views to standardize behavior and resolve warnings.

### Requirements

- [ ] Unit tests added/updated
- [ ] Documentation updated (if applicable