### PR TITLE
Restore and persist selected line state across sessions

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/BookContentViewModel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/BookContentViewModel.kt
@@ -117,15 +117,13 @@ class BookContentViewModel(
                 if (requestedLineId != null) {
                     loadBookById(restoredBook.id, requestedLineId)
                 } else {
-                    loadBookData(restoredBook)
-                }
-
-                // Restaurer la ligne sélectionnée et recalculer le TOC/breadcrumb
-                stateManager.state.value.content.selectedLine?.let { line ->
-                    // Also rebuild TOC selection + breadcrumb from the restored line
-                    contentUseCase.selectLine(line)
-                    commentariesUseCase.reapplySelectedCommentators(line)
-                    commentariesUseCase.reapplySelectedLinkSources(line)
+                    // Vérifier s'il y a une ligne sélectionnée sauvegardée à restaurer
+                    val savedLineId = tabStateManager.getState<Long>(currentTabId, StateKeys.SELECTED_LINE_ID)
+                    if (savedLineId != null) {
+                        loadBookById(restoredBook.id, savedLineId)
+                    } else {
+                        loadBookData(restoredBook)
+                    }
                 }
             } else {
                 // Charger depuis les paramètres

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/BookContentStateManager.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/BookContentStateManager.kt
@@ -196,7 +196,10 @@ class BookContentStateManager(
         saveState(StateKeys.TOC_SCROLL_OFFSET, currentState.toc.scrollOffset)
         
         // Content
-        currentState.content.selectedLine?.let { saveState(StateKeys.SELECTED_LINE, it) }
+        currentState.content.selectedLine?.let { 
+            saveState(StateKeys.SELECTED_LINE, it)
+            saveState(StateKeys.SELECTED_LINE_ID, it.id)
+        }
         saveState(StateKeys.SHOW_COMMENTARIES, currentState.content.showCommentaries)
         saveState(StateKeys.SHOW_TARGUM, currentState.content.showTargum)
         saveState(StateKeys.CONTENT_SCROLL_INDEX, currentState.content.scrollIndex)

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/StateKeys.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/StateKeys.kt
@@ -29,6 +29,7 @@ object StateKeys {
     
     // Content
     const val SELECTED_LINE = "selectedLine"
+    const val SELECTED_LINE_ID = "selectedLineId"
     const val SHOW_COMMENTARIES = "showCommentaries"
     const val SHOW_TARGUM = "showTargum"
     const val PARAGRAPH_SCROLL_POSITION = "paragraphScrollPosition"


### PR DESCRIPTION
### Summary
This pull request ensures that the selected line ID in a book is restored and persisted across sessions.

### Changes Made
- Introduced `SELECTED_LINE_ID` to preserve the state of the selected line.
- Updated `BookContentStateManager` to save