### PR TITLE
Rename macOS .pkg files

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    gradlePluginPortal()
+    mavenCentral()
+}


### PR DESCRIPTION
### Summary

- Added `renameMacPkg` task to append _arm64 or _x64 suffix to macOS .pkg files.
- Configured the task to execute following the Compose Desktop package tasks for macOS.
- Updated `buildSrc` to include necessary Kotlin DSL settings. 

### Impact

This change simplifies distinguishing between architecture-specific .pkg files for macOS distributions.