### PR TITLE
Sync user profile name with reactive data and persist

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/settings/AppSettings.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/settings/AppSettings.kt
@@ -76,6 +76,9 @@ object AppSettings {
         _commentaryFontCodeFlow.value = getCommentaryFontCode()
         _targumFontCodeFlow.value = getTargumFontCode()
         _ramSaverEnabledFlow.value = isRamSaverEnabled()
+        // User profile reactive values
+        _userFirstNameFlow.value = getUserFirstName() ?: ""
+        _userLastNameFlow.value = getUserLastName() ?: ""
     }
 
     // StateFlow to observe text size changes
@@ -292,6 +295,13 @@ object AppSettings {
     }
 
     // User profile accessors
+    // Reactive flows to observe user identity changes across the app
+    private val _userFirstNameFlow = MutableStateFlow(getUserFirstName() ?: "")
+    val userFirstNameFlow: StateFlow<String> = _userFirstNameFlow.asStateFlow()
+
+    private val _userLastNameFlow = MutableStateFlow(getUserLastName() ?: "")
+    val userLastNameFlow: StateFlow<String> = _userLastNameFlow.asStateFlow()
+
     fun getUserFirstName(): String? {
         val value: String = settings[KEY_USER_FIRST_NAME, ""]
         return value.ifBlank { null }
@@ -299,6 +309,7 @@ object AppSettings {
 
     fun setUserFirstName(value: String?) {
         settings[KEY_USER_FIRST_NAME] = value?.takeIf { it.isNotBlank() } ?: ""
+        _userFirstNameFlow.value = getUserFirstName() ?: ""
     }
 
     fun getUserLastName(): String? {
@@ -308,6 +319,7 @@ object AppSettings {
 
     fun setUserLastName(value: String?) {
         settings[KEY_USER_LAST_NAME] = value?.takeIf { it.isNotBlank() } ?: ""
+        _userLastNameFlow.value = getUserLastName() ?: ""
     }
 
     // Community is stored as a stable code (enum name), not a localized label

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/ProfileSettingsScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/ProfileSettingsScreen.kt
@@ -81,6 +81,8 @@ private fun ProfileSettingsView(
                 LaunchedEffect(firstNameState.text) {
                     val value = firstNameState.text.toString()
                     if (value != state.firstName) onEvent(UserProfileEvents.FirstNameChanged(value))
+                    // Persist immediately to keep behavior consistent with other settings
+                    AppSettings.setUserFirstName(value.trim())
                 }
                 TextField(state = firstNameState, modifier = Modifier.widthIn(max = 240.dp))
             }
@@ -94,6 +96,8 @@ private fun ProfileSettingsView(
                 LaunchedEffect(lastNameState.text) {
                     val value = lastNameState.text.toString()
                     if (value != state.lastName) onEvent(UserProfileEvents.LastNameChanged(value))
+                    // Persist immediately to keep behavior consistent with other settings
+                    AppSettings.setUserLastName(value.trim())
                 }
                 TextField(state = lastNameState, modifier = Modifier.widthIn(max = 240.dp))
             }
@@ -111,7 +115,11 @@ private fun ProfileSettingsView(
                 ListComboBox(
                     items = communityLabels,
                     selectedIndex = state.selectedCommunityIndex,
-                    onSelectedItemChange = { index -> onEvent(UserProfileEvents.SelectCommunity(index)) }
+                    onSelectedItemChange = { index ->
+                        onEvent(UserProfileEvents.SelectCommunity(index))
+                        val community = state.communities.getOrNull(index)
+                        AppSettings.setUserCommunityCode(community?.name)
+                    }
                 )
             }
         }


### PR DESCRIPTION
### Summary of Changes
- Integrated `userFirstNameFlow` and `userLastNameFlow` in `AppSettings` to support reactive user profile name updates.
- Modified `SearchHomeViewModel` to observe and synchronize display name changes dynamically.
- Enabled real-time persistence of user profile name edits in `ProfileSettingsScreen`.
- Fix #46