### PR TITLE
Add type-safe hint for book open source in UI flows

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/BookOpenSource.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/BookOpenSource.kt
@@ -1,0 +1,10 @@
+package io.github.kdroidfilter.seforimapp.features.bookcontent.state
+
+/**
+ * Type‑safe hint of where a book open action originated from.
+ * Used to tailor initial UI (e.g., showing TOC) only for specific flows.
+ */
+enum class BookOpenSource {
+    HOME_REFERENCE
+}
+

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/StateKeys.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/StateKeys.kt
@@ -8,6 +8,8 @@ object StateKeys {
     const val TAB_ID = "tabId"
     const val BOOK_ID = "bookId"
     const val LINE_ID = "lineId"
+    // Source hints for book opening (ephemeral)
+    const val OPEN_SOURCE = "bookOpenSource"
     
     // Navigation
     const val SELECTED_BOOK = "selectedBook"

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchHomeViewModel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchHomeViewModel.kt
@@ -447,6 +447,12 @@ class SearchHomeViewModel(
         // Pre-initialize minimal state so the BookContent shell does not flash Home
         stateManager.saveState(currentTabId, io.github.kdroidfilter.seforimapp.features.bookcontent.state.StateKeys.SELECTED_BOOK, book)
         anchorLineId?.let { stateManager.saveState(currentTabId, io.github.kdroidfilter.seforimapp.features.bookcontent.state.StateKeys.CONTENT_ANCHOR_ID, it) }
+        // Type-safe hint that this open came from Home/Reference predictive flow
+        stateManager.saveState(
+            currentTabId,
+            io.github.kdroidfilter.seforimapp.features.bookcontent.state.StateKeys.OPEN_SOURCE,
+            io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookOpenSource.HOME_REFERENCE
+        )
 
         // Replace destination in-place to open the book
         tabsViewModel.replaceCurrentTabDestination(


### PR DESCRIPTION
### Description of changes

- Introduced a `BookOpenSource` enum to define the origin of book open actions, allowing for more tailored user interface behavior.
- Enhanced `BookContentViewModel` to ensure the table of contents (TOC) displays properly when opening a book from the Home or Reference context.
- Added a new `OPEN_SOURCE` key to `StateKeys` for temporarily storing source-related data.
- Updated `SearchHomeViewModel` to track predictive flows by assigning `BookOpenSource.HOME_REFERENCE`.
