### PR TITLE
Migrate to ProtoBuf and enhance state restoration in search

### DIFF
--- a/SeforimApp/build.gradle.kts
+++ b/SeforimApp/build.gradle.kts
@@ -72,6 +72,7 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.datetime)
             implementation(libs.kotlinx.serialization.json)
+            implementation(libs.kotlinx.serialization.protobuf)
 
             // Settings & platform utils
             implementation(libs.multiplatformSettings)

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchTabPersistentCache.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchTabPersistentCache.kt
@@ -3,15 +3,22 @@ package io.github.kdroidfilter.seforimapp.features.search
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.databasesDir
 import io.github.vinceglb.filekit.path
-import kotlinx.serialization.json.Json
 import java.io.File
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.protobuf.ProtoBuf
 
 /**
  * Persists SearchTabCache snapshots to disk so they can be restored on cold boot
  * without re-running the search.
+ *
+ * Previously JSON was used; we now use ProtoBuf for faster, smaller IO.
+ * JSON fallback is kept for a smooth one-time migration from existing caches.
  */
 object SearchTabPersistentCache {
+    // JSON kept only for backward-compat load of existing cache files
     private val json = Json { encodeDefaults = true; ignoreUnknownKeys = true }
+    // ProtoBuf for new saves/loads
+    private val proto = ProtoBuf
 
     private fun baseDir(): File {
         // Use a subdirectory next to the DB location to keep related data together
@@ -22,27 +29,47 @@ object SearchTabPersistentCache {
 
     private fun sanitize(name: String): String = name.replace(Regex("[^A-Za-z0-9._-]"), "_")
 
-    private fun fileFor(tabId: String): File = File(baseDir(), "tab_${sanitize(tabId)}.json")
+    private fun binFileFor(tabId: String): File = File(baseDir(), "tab_${sanitize(tabId)}.pb")
+    private fun jsonFileFor(tabId: String): File = File(baseDir(), "tab_${sanitize(tabId)}.json")
 
     fun save(tabId: String, snapshot: SearchTabCache.Snapshot) {
         runCatching {
-            val file = fileFor(tabId)
-            val text = json.encodeToString(SearchTabCache.Snapshot.serializer(), snapshot)
-            file.writeText(text)
+            val file = binFileFor(tabId)
+            val bytes = proto.encodeToByteArray(SearchTabCache.Snapshot.serializer(), snapshot)
+            file.writeBytes(bytes)
+            // Best-effort cleanup of any legacy JSON file
+            runCatching { jsonFileFor(tabId).delete() }
         }
     }
 
     fun load(tabId: String): SearchTabCache.Snapshot? {
-        return runCatching {
-            val file = fileFor(tabId)
-            if (!file.exists()) return@runCatching null
-            val text = file.readText()
-            json.decodeFromString(SearchTabCache.Snapshot.serializer(), text)
-        }.getOrNull()
+        // Prefer ProtoBuf; fallback to legacy JSON once, then re-save in ProtoBuf
+        binFileFor(tabId).let { bin ->
+            if (bin.exists()) {
+                return runCatching {
+                    val bytes = bin.readBytes()
+                    proto.decodeFromByteArray(SearchTabCache.Snapshot.serializer(), bytes)
+                }.getOrNull()
+            }
+        }
+
+        // Legacy JSON migration path
+        jsonFileFor(tabId).let { js ->
+            if (js.exists()) {
+                val snap = runCatching {
+                    val text = js.readText()
+                    json.decodeFromString(SearchTabCache.Snapshot.serializer(), text)
+                }.getOrNull()
+                // If parsed, immediately rewrite as ProtoBuf for next time
+                if (snap != null) save(tabId, snap)
+                return snap
+            }
+        }
+        return null
     }
 
     fun clear(tabId: String) {
-        runCatching { fileFor(tabId).delete() }
+        runCatching { binFileFor(tabId).delete() }
+        runCatching { jsonFileFor(tabId).delete() }
     }
 }
-

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 jvm-native-trusted-roots = { module = "org.jetbrains.nativecerts:jvm-native-trusted-roots", version.ref = "jvmNativeTrustedRoots" }
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 koalaplot-core = { module = "io.github.koalaplot:koalaplot-core", version.ref = "koalaplotCore" }
+kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "kotlinx-serialization" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }


### PR DESCRIPTION
### Description

This pull request includes the following changes:
- Migrates search and session data from JSON to ProtoBuf to improve performance and reduce the I/O footprint. Legacy JSON data is handled via one-time migration with fallback mechanisms.
- Updates the `SearchResultScreen` component to restore scroll state based on an anchor timestamp. Introduces `lastRestoredTs` for accurate and consistent restoration handling during new searches or filter changes.
