### PR TITLE
Add precomputed search tree snapshots for faster cold restores

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchTabCache.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchTabCache.kt
@@ -20,6 +20,20 @@ object SearchTabCache {
     )
 
     @Serializable
+    data class SearchTreeBookSnapshot(
+        val book: Book,
+        val count: Int
+    )
+
+    @Serializable
+    data class SearchTreeCategorySnapshot(
+        val category: io.github.kdroidfilter.seforimlibrary.core.models.Category,
+        val count: Int,
+        val children: List<SearchTreeCategorySnapshot>,
+        val books: List<SearchTreeBookSnapshot>
+    )
+
+    @Serializable
     data class TocTreeSnapshot(
         val rootEntries: List<TocEntry>,
         val children: Map<Long, List<TocEntry>>
@@ -30,7 +44,9 @@ object SearchTabCache {
         val results: List<SearchResult>,
         val categoryAgg: CategoryAggSnapshot,
         val tocCounts: Map<Long, Int>,
-        val tocTree: TocTreeSnapshot?
+        val tocTree: TocTreeSnapshot?,
+        // Optional precomputed search tree to accelerate restore
+        val searchTree: List<SearchTreeCategorySnapshot>? = null
     )
 
     private val cache = object : LinkedHashMap<String, Snapshot>(16, 0.75f, true) {


### PR DESCRIPTION
Enhance the application's performance during cold restores by introducing and integrating precomputed search tree snapshots. This includes:

- Adding `SearchTreeCategorySnapshot` and `SearchTreeBookSnapshot` for serializing search tree states.
- Updating the `SearchTabCache.Snapshot` to handle optional `searchTree` snapshots.
- Modifying `CategoryBookTreeView` scroll mechanisms to ensure restoration order aligns with persistence processes.
- Improving `SearchResultViewModel` to deserialize and restore precomputed search trees and save serialized states efficiently. 

This ensures smoother and faster user experiences during state restorations.