### PR TITLE
Add OS-specific keyboard shortcuts for Home action

### DIFF
--- a/SeforimApp/src/commonMain/composeResources/values/strings.xml
+++ b/SeforimApp/src/commonMain/composeResources/values/strings.xml
@@ -16,6 +16,9 @@
     <string name="home_tooltip">עבור לדף הבית</string>
     <string name="titlebar_home">דף הבית</string>
     <string name="titlebar_home_tooltip">עבור לדף הבית</string>
+    <!-- Shortcut hints (OS-specific) for Home action -->
+    <string name="shortcut_home_mac">⌘+⇧+H</string>
+    <string name="shortcut_home_windows">Alt+Home</string>
     <string name="info">מידע</string>
     <string name="info_tooltip">הצג מידע</string>
     <string name="settings">הגדרות</string>

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/TitleBarActionsButtonsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/TitleBarActionsButtonsView.kt
@@ -6,6 +6,8 @@ import io.github.kdroidfilter.seforim.tabs.TabStateManager
 import io.github.kdroidfilter.seforim.tabs.TabsDestination
 import io.github.kdroidfilter.seforim.tabs.TabsViewModel
 import io.github.kdroidfilter.seforimapp.core.MainAppState
+import io.github.kdroidfilter.platformtools.OperatingSystem
+import io.github.kdroidfilter.platformtools.getOperatingSystem
 import io.github.kdroidfilter.seforimapp.core.presentation.theme.IntUiThemes
 import io.github.kdroidfilter.seforimapp.core.settings.AppSettings
 import io.github.kdroidfilter.seforimapp.features.settings.SettingsWindow
@@ -53,6 +55,10 @@ fun TitleBarActionsButtonsView() {
         IntUiThemes.System -> stringResource(Res.string.switch_to_light_theme)
     }
 
+    val homeShortcutHint = if (getOperatingSystem() == OperatingSystem.MACOS)
+        stringResource(Res.string.shortcut_home_mac)
+    else stringResource(Res.string.shortcut_home_windows)
+
     TitleBarActionButton(
         key = AllIconsKeys.Nodes.HomeFolder,
         contentDescription = stringResource(Res.string.home),
@@ -71,6 +77,7 @@ fun TitleBarActionsButtonsView() {
             }
         },
         tooltipText = stringResource(Res.string.home_tooltip),
+        shortcutHint = homeShortcutHint,
     )
     TitleBarActionButton(
         key = AllIconsKeys.Actions.Find,

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/main.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/main.kt
@@ -48,6 +48,7 @@ import java.util.*
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isAltPressed
 import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
@@ -56,6 +57,7 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.Box
 import io.github.kdroidfilter.seforim.tabs.TabsEvents
+import io.github.kdroidfilter.seforim.tabs.TabsDestination
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalTrayAppApi::class)
 fun main() {
@@ -171,6 +173,17 @@ fun main() {
                                         tabsVm.onEvent(TabsEvents.onSelected(newIndex))
                                     }
                                     true
+                                } else if ((keyEvent.isAltPressed && keyEvent.key == Key.Home) ||
+                                    (keyEvent.isMetaPressed && keyEvent.isShiftPressed && keyEvent.key == Key.H)
+                                ) {
+                                    val currentTabId = tabs.getOrNull(selectedIndex)?.destination?.tabId
+                                    if (currentTabId != null) {
+                                        // Navigate current tab back to Home (preserve tab slot, refresh state)
+                                        tabsVm.replaceCurrentTabWithNewTabId(TabsDestination.Home(currentTabId))
+                                        true
+                                    } else {
+                                        false
+                                    }
                                 } else {
                                     processKeyShortcuts(
                                         keyEvent = keyEvent,
@@ -237,6 +250,15 @@ fun main() {
                                         isCtrlOrCmd && keyEvent.key == Key.T -> {
                                             tabsVm.onEvent(TabsEvents.onAdd)
                                             true
+                                        }
+                                        // Alt + Home (Windows) or Cmd + Shift + H (macOS) => go Home on current tab
+                                        (keyEvent.isAltPressed && keyEvent.key == Key.Home) ||
+                                                (keyEvent.isMetaPressed && keyEvent.isShiftPressed && keyEvent.key == Key.H) -> {
+                                            val currentTabId = tabs.getOrNull(selectedIndex)?.destination?.tabId
+                                            if (currentTabId != null) {
+                                                tabsVm.replaceCurrentTabWithNewTabId(TabsDestination.Home(currentTabId))
+                                                true
+                                            } else false
                                         }
                                         else -> false
                                     }


### PR DESCRIPTION
### What does this implement/fix?
This pull request introduces OS-specific keyboard shortcuts for the Home action. It dynamically updates shortcut hints in the UI for macOS and Windows users and allows navigating to the Home screen using `⌘+⇧+H` on macOS or `Alt+Home` on Windows.

### Changes include:
- OS-specific shortcut hints added in string resources.
- Dynamic shortcut hint functionality in `TitleBarActionsButtonsView`.
- Keyboard shortcut handling added to `main.kt`.



