### PR TITLE
Add support for TOC visibility on first open from search results

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/BookContentViewModel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/BookContentViewModel.kt
@@ -126,7 +126,8 @@ class BookContentViewModel(
                         val openSource: io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookOpenSource? =
                             tabStateManager.getState(currentTabId, StateKeys.OPEN_SOURCE)
                         if (openSource == io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookOpenSource.HOME_REFERENCE ||
-                            openSource == io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookOpenSource.CATEGORY_TREE_NEW_TAB) {
+                            openSource == io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookOpenSource.CATEGORY_TREE_NEW_TAB ||
+                            openSource == io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookOpenSource.SEARCH_RESULT) {
                             ensureTocVisibleOnFirstOpen()
                         }
                         loadBookData(restoredBook)
@@ -283,7 +284,8 @@ class BookContentViewModel(
                 val openSource: io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookOpenSource? =
                     tabStateManager.getState(currentTabId, StateKeys.OPEN_SOURCE)
                 if (openSource == io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookOpenSource.HOME_REFERENCE ||
-                    openSource == io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookOpenSource.CATEGORY_TREE_NEW_TAB) {
+                    openSource == io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookOpenSource.CATEGORY_TREE_NEW_TAB ||
+                    openSource == io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookOpenSource.SEARCH_RESULT) {
                     ensureTocVisibleOnFirstOpen()
                 }
 

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/BookOpenSource.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/BookOpenSource.kt
@@ -6,5 +6,6 @@ package io.github.kdroidfilter.seforimapp.features.bookcontent.state
  */
 enum class BookOpenSource {
     HOME_REFERENCE,
-    CATEGORY_TREE_NEW_TAB
+    CATEGORY_TREE_NEW_TAB,
+    SEARCH_RESULT
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchResultViewModel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchResultViewModel.kt
@@ -1487,6 +1487,12 @@ class SearchResultViewModel(
                 stateManager.saveState(newTabId, StateKeys.SELECTED_BOOK, book)
             }
             stateManager.saveState(newTabId, StateKeys.CONTENT_ANCHOR_ID, result.lineId)
+            // Hint BookContent to show TOC on first open from search
+            stateManager.saveState(
+                newTabId,
+                StateKeys.OPEN_SOURCE,
+                io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookOpenSource.SEARCH_RESULT
+            )
 
             tabsViewModel.openTab(
                 TabsDestination.BookContent(
@@ -1514,6 +1520,12 @@ class SearchResultViewModel(
                 stateManager.saveState(tabId, StateKeys.SELECTED_BOOK, book)
             }
             stateManager.saveState(tabId, StateKeys.CONTENT_ANCHOR_ID, result.lineId)
+            // Hint BookContent to show TOC on first open from search in the current tab
+            stateManager.saveState(
+                tabId,
+                StateKeys.OPEN_SOURCE,
+                io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookOpenSource.SEARCH_RESULT
+            )
 
             // Swap current tab destination to BookContent while preserving tabId
             tabsViewModel.replaceCurrentTabDestination(


### PR DESCRIPTION
- **Summary of Changes**:
  - Added a new `BookOpenSource` type: `SEARCH_RESULT`.
  - Adjusted TOC visibility logic for tabs originating from search.
  - Implemented state saving for `SEARCH_RESULT` during navigation.

