### PR TITLE
Reverse tab addition order for RTL layouts

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsView.kt
@@ -242,7 +242,9 @@ private fun RtlAwareTabStripWithAddButton(
             // si première frame = maxValue encore 0, attendre encore une frame
             if (scrollState.maxValue == 0) withFrameNanos { }
 
-            val target = scrollState.maxValue
+            // En RTL, les nouveaux onglets s'ajoutent à gauche, donc on scroll vers 0
+            // En LTR, les nouveaux onglets s'ajoutaient à droite, donc on scrollait vers maxValue
+            val target = if (isRtl) 0 else scrollState.maxValue
             scrollState.animateScrollTo(target)
         }
     }

--- a/navigation/src/commonMain/kotlin/io/github/kdroidfilter/seforim/tabs/TabsViewModel.kt
+++ b/navigation/src/commonMain/kotlin/io/github/kdroidfilter/seforim/tabs/TabsViewModel.kt
@@ -118,8 +118,8 @@ class TabsViewModel(
             destination = destination,
             tabType = TabType.SEARCH
         )
-        _tabs.value = _tabs.value + newTab
-        _selectedTabIndex.value = _tabs.value.lastIndex
+        _tabs.value = listOf(newTab) + _tabs.value
+        _selectedTabIndex.value = 0
         // Trigger GC when a new tab is opened via the plus button
         System.gc()
     }
@@ -142,8 +142,8 @@ class TabsViewModel(
                 is TabsDestination.BookContent -> if (newDestination.bookId > 0) TabType.BOOK else TabType.SEARCH
             }
         )
-        _tabs.value = _tabs.value + newTab
-        _selectedTabIndex.value = _tabs.value.lastIndex
+        _tabs.value = listOf(newTab) + _tabs.value
+        _selectedTabIndex.value = 0
     }
 
     /**


### PR DESCRIPTION
Updated tab addition logic to prepend new tabs rather than appending them while maintaining appropriate scrolling behavior for right-to-left (RTL) layouts. Ensures selected tabs align properly regardless of layout direction.
Fix #97