### PR TITLE
Persist theme mode and enhance tab reordering logic

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/MainAppState.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/MainAppState.kt
@@ -1,6 +1,7 @@
 package io.github.kdroidfilter.seforimapp.core
 
 import io.github.kdroidfilter.seforimapp.core.presentation.theme.IntUiThemes
+import io.github.kdroidfilter.seforimapp.core.settings.AppSettings
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -12,6 +13,7 @@ object MainAppState {
 
     fun setTheme(theme: IntUiThemes) {
         _theme.value = theme
+        AppSettings.setThemeMode(theme)
     }
 
     private val _showOnboarding = MutableStateFlow<Boolean?>(null)

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/settings/AppSettings.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/settings/AppSettings.kt
@@ -3,6 +3,7 @@ package io.github.kdroidfilter.seforimapp.core.settings
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.get
 import com.russhwolf.settings.set
+import io.github.kdroidfilter.seforimapp.core.presentation.theme.IntUiThemes
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -58,6 +59,9 @@ object AppSettings {
     private const val KEY_USER_FIRST_NAME = "user_first_name"
     private const val KEY_USER_LAST_NAME = "user_last_name"
     private const val KEY_USER_COMMUNITY = "user_community" // stores a stable code (e.g., "SEPHARADE")
+
+    // Theme configuration
+    private const val KEY_THEME_MODE = "theme_mode"
 
     // Backing Settings storage (can be replaced at startup if needed)
     @Volatile
@@ -330,6 +334,20 @@ object AppSettings {
 
     fun setUserCommunityCode(value: String?) {
         settings[KEY_USER_COMMUNITY] = value?.takeIf { it.isNotBlank() } ?: ""
+    }
+
+    // Theme mode (Light/Dark/System) setting
+    fun getThemeMode(): IntUiThemes {
+        val storedValue: String = settings[KEY_THEME_MODE, IntUiThemes.System.name]
+        return try {
+            IntUiThemes.valueOf(storedValue)
+        } catch (_: IllegalArgumentException) {
+            IntUiThemes.System
+        }
+    }
+
+    fun setThemeMode(theme: IntUiThemes) {
+        settings[KEY_THEME_MODE] = theme.name
     }
 
     fun setSavedSessionJson(json: String?) {

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/main.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/main.kt
@@ -110,6 +110,8 @@ fun main() {
         val appGraph = remember { createGraph<AppGraph>() }
         // Ensure AppSettings uses the DI-provided Settings immediately
         AppSettings.initialize(appGraph.settings)
+        // Restore previously selected theme (Light/Dark/System) from settings
+        MainAppState.setTheme(AppSettings.getThemeMode())
 
         CompositionLocalProvider(LocalAppGraph provides appGraph) {
             val themeDefinition = ThemeUtils.buildThemeDefinition()


### PR DESCRIPTION
---

### Changes Introduced

1. **Persist and Restore Theme Mode**:
   - Added methods `setThemeMode` and `getThemeMode` in `AppSettings` for saving and loading theme preferences.
   - Integrated theme persistence in `MainAppState` and initialized saved theme on app startup.

2. **Enhance Tab Reordering Logic**:
   - Introduced `tabEntriesByKey` mapping for efficient tab lookup.
   - Updated `ReorderableRow` to use `currentKeys`, improving reordering performance.
   - Added drag-start behavior for tab selection, providing better UX similar to Chrome.
   - Enhanced handling of tab closures and related animations.

### References

N/A

### Verification Checklist

- [ ] Code changes