### PR TITLE
Remove unused precomputation logic in SearchHomeViewModel

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchHomeViewModel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchHomeViewModel.kt
@@ -264,25 +264,6 @@ class SearchHomeViewModel(
                 }
         }
 
-        // Precompute a small set of (book, toc) pairs for synchronized placeholders
-        viewModelScope.launch {
-            val pairs = try {
-                withContext(Dispatchers.IO) {
-                    val out = mutableListOf<Pair<String, String>>()
-                    val books = repository.getAllBooks()
-                    for (b in books) {
-                        val toc = try { repository.getBookToc(b.id) } catch (_: Exception) { emptyList() }
-                        val first = toc.firstOrNull { it.text.isNotBlank() }?.text
-                        if (first != null && out.none { it.first == b.title }) {
-                            out += b.title to first
-                        }
-                        if (out.size >= 5) break
-                    }
-                    out
-                }
-            } catch (_: Exception) { emptyList() }
-            _uiState.value = _uiState.value.copy(pairedReferenceHints = pairs)
-        }
     }
 
     fun onReferenceQueryChanged(query: String) {


### PR DESCRIPTION
This pull request removes redundant precomputation logic for paired reference hints in the `SearchHomeViewModel`. The logic was no longer required and its removal helps in simplifying the codebase. No functional changes were introduced.