### PR TITLE
Update Windows packaging and optimize JVM configuration

### DIFF
--- a/SeforimApp/build.gradle.kts
+++ b/SeforimApp/build.gradle.kts
@@ -206,8 +206,7 @@ compose.desktop {
                 iconFile.set(project.file("desktopAppIcons/WindowsIcon.ico"))
                 packageVersion = version
                 packageName = "Zayit"
-                dirChooser = true
-                menuGroup = "start-menu-group"
+                dirChooser = false
                 shortcut = true
                 upgradeUuid = "d9f21975-4359-4818-a623-6e9a3f0a07ca"
                 perUserInstall = true


### PR DESCRIPTION
---

### Changes

- Disabled `dirChooser` and enabled `shortcut` creation for Windows package configuration.
- Set ProGuard version to `7.8.1` in release build configuration.
- Updated `jvmToolchain` to version `25` in `libs.versions.toml`.
- Optimized JVM memory usage by adding arguments for:
  - Compact object headers (`-XX:+UseCompactObjectHeaders`).
  - String deduplication (`-XX:+UseStringDeduplication`).
  - Reduced garbage collection pause times (`-XX:MaxGCPauseMillis=50`).

### Checklist

- [ ] The code builds without any errors.
- [ ] Tests have been added/updated to cover the changes.
- [ ] Documentation has been updated if required.