### PR TITLE
Refactor DownloadScreen to streamline cleanup and download flow

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/onboarding/download/DownloadScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/onboarding/download/DownloadScreen.kt
@@ -61,23 +61,11 @@ fun DownloadScreen(
         progressBarState.setProgress(anchored)
     }
 
-    // Trigger download once when entering this screen
-    var started by remember { mutableStateOf(false) }
-    var cleanupCompleted by remember { mutableStateOf(false) }
-    
+    // Trigger cleanup and download once when entering this screen
     LaunchedEffect(Unit) {
-        // Nettoyer les anciens fichiers de base de données avant de commencer
-        if (!cleanupCompleted) {
-            cleanupUseCase.cleanupDatabaseFiles()
-            cleanupCompleted = true
-        }
-    }
-    
-    LaunchedEffect(state.inProgress, state.completed) {
-        if (!started && !state.inProgress && !state.completed && cleanupCompleted) {
-            started = true
-            viewModel.onEvent(DownloadEvents.Start)
-        }
+        // Clean up old database files before starting the download
+        cleanupUseCase.cleanupDatabaseFiles()
+        viewModel.onEvent(DownloadEvents.Start)
     }
 
     // Clear back stack once download starts to prevent going back


### PR DESCRIPTION
- Removed redundant state variables `started` and `cleanupCompleted`, simplifying state management.
- Consolidated cleanup and download flow logic into a single `LaunchedEffect` for better clarity and maintainability.