### PR TITLE
Fix sources split defaults

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/BookContentState.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/BookContentState.kt
@@ -162,7 +162,7 @@ data class ContentState(
 data class LayoutState @OptIn(ExperimentalSplitPaneApi::class) constructor(
     val mainSplitState: SplitPaneState = SplitPaneState(initialPositionPercentage = SplitDefaults.MAIN, moveEnabled = true),
     val tocSplitState: SplitPaneState = SplitPaneState(initialPositionPercentage = SplitDefaults.TOC, moveEnabled = true),
-    val contentSplitState: SplitPaneState = SplitPaneState(initialPositionPercentage = 0.7f, moveEnabled = true),
+    val contentSplitState: SplitPaneState = SplitPaneState(initialPositionPercentage = SplitDefaults.CONTENT, moveEnabled = true),
     val targumSplitState: SplitPaneState = SplitPaneState(initialPositionPercentage = 0.8f, moveEnabled = true),
     val previousPositions: PreviousPositions = PreviousPositions()
 )
@@ -171,6 +171,7 @@ data class LayoutState @OptIn(ExperimentalSplitPaneApi::class) constructor(
 data class PreviousPositions(
     val main: Float = SplitDefaults.MAIN,
     val toc: Float = SplitDefaults.TOC,
-    val content: Float = 0.7f,
+    val content: Float = SplitDefaults.CONTENT,
+    val sources: Float = SplitDefaults.SOURCES,
     val links: Float = 0.8f
 )

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/BookContentStateManager.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/BookContentStateManager.kt
@@ -85,6 +85,7 @@ class BookContentStateManager(
                     main = persisted.previousMainSplitPosition,
                     toc = persisted.previousTocSplitPosition,
                     content = persisted.previousContentSplitPosition,
+                    sources = persisted.previousSourcesSplitPosition,
                     links = persisted.previousTargumSplitPosition
                 )
             )
@@ -233,6 +234,7 @@ class BookContentStateManager(
             previousMainSplitPosition = currentState.layout.previousPositions.main,
             previousTocSplitPosition = currentState.layout.previousPositions.toc,
             previousContentSplitPosition = currentState.layout.previousPositions.content,
+            previousSourcesSplitPosition = currentState.layout.previousPositions.sources,
             previousTargumSplitPosition = currentState.layout.previousPositions.links,
         )
 

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/SplitDefaults.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/SplitDefaults.kt
@@ -9,6 +9,8 @@ object SplitDefaults {
     // Default position percentages
     const val MAIN: Float = 0.05f // default for mainSplitState (Category panel)
     const val TOC: Float = 0.05f  // default for tocSplitState (TOC panel)
+    const val CONTENT: Float = 0.7f // default for contentSplitState (Commentaries panel)
+    const val SOURCES: Float = 0.85f // default for Sources panel (smaller than Commentaries)
 
     // Minimum sizes (pixels) for the first pane of each split
     const val MIN_MAIN: Float = 150f

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/StateKeys.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/StateKeys.kt
@@ -66,5 +66,6 @@ object StateKeys {
     const val PREVIOUS_MAIN_SPLIT_POSITION = "previousMainSplitPosition"
     const val PREVIOUS_TOC_SPLIT_POSITION = "previousTocSplitPosition"
     const val PREVIOUS_CONTENT_SPLIT_POSITION = "previousContentSplitPosition"
+    const val PREVIOUS_SOURCES_SPLIT_POSITION = "previousSourcesSplitPosition"
     const val PREVIOUS_TARGUM_SPLIT_POSITION = "previousTargumSplitPosition"
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/usecases/ContentUseCase.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/usecases/ContentUseCase.kt
@@ -244,14 +244,14 @@ class ContentUseCase(
             stateManager.updateLayout {
                 copy(
                     previousPositions = previousPositions.copy(
-                        content = prev
+                        sources = prev
                     )
                 )
             }
             newPosition = 1f
             currentState.layout.contentSplitState.positionPercentage = newPosition
         } else {
-            newPosition = currentState.layout.previousPositions.content
+            newPosition = currentState.layout.previousPositions.sources
             currentState.layout.contentSplitState.positionPercentage = newPosition
         }
 

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/session/SessionModels.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/session/SessionModels.kt
@@ -77,11 +77,12 @@ data class BookContentPersistedState(
     // Layout
     val mainSplitPosition: Float = SplitDefaults.MAIN,
     val tocSplitPosition: Float = SplitDefaults.TOC,
-    val contentSplitPosition: Float = 0.7f,
+    val contentSplitPosition: Float = SplitDefaults.CONTENT,
     val targumSplitPosition: Float = 0.8f,
     val previousMainSplitPosition: Float = SplitDefaults.MAIN,
     val previousTocSplitPosition: Float = SplitDefaults.TOC,
-    val previousContentSplitPosition: Float = 0.7f,
+    val previousContentSplitPosition: Float = SplitDefaults.CONTENT,
+    val previousSourcesSplitPosition: Float = SplitDefaults.SOURCES,
     val previousTargumSplitPosition: Float = 0.8f,
 )
 


### PR DESCRIPTION
## Summary
- add shared defaults for content and sources split positions
- persist previous sources split position alongside existing split state
- restore sources toggle using its own saved position rather than content position

## Modules
- SeforimApp

## Testing
- not run (not requested)