### PR TITLE
Fix Home view zoom causing logo overlap and cropping

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeView.kt
@@ -188,8 +188,12 @@ private fun HomeBody(
             val maxScaleForWidth = (maxWidth.value / baseWidth.value).coerceAtLeast(0f)
             val clampedScale = homeScale.coerceAtMost(maxScaleForWidth).coerceAtLeast(0f)
 
+            // Scale paddings and spacing proportionally so zoomed content has adequate room
+            val scaledTopPadding = (56.dp * clampedScale).coerceAtLeast(56.dp)
+            val scaledSpacing = (16.dp * clampedScale).coerceAtLeast(16.dp)
+
             Box(
-                modifier = modifier.padding(top = 56.dp).fillMaxSize().padding(8.dp),
+                modifier = modifier.padding(top = scaledTopPadding).fillMaxSize().padding(8.dp),
                 contentAlignment = Alignment.Center
             ) {
                 // Keep state outside LazyColumn so it persists across item recompositions
@@ -254,21 +258,33 @@ private fun HomeBody(
                     scaleY = clampedScale
                 )
 
+                // Logo and search bar base heights - used to reserve correct layout space
+                val logoBaseSize = 220.dp
+                val searchBarBaseHeight = 40.dp
+
                 LazyColumn(
                     state = listState,
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(scaledSpacing),
                     modifier = Modifier.fillMaxWidth()
                 ) {
 
                     item {
-                        Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                        // Reserve scaled height so the visually scaled logo doesn't overflow
+                        Box(
+                            Modifier.fillMaxWidth().height(logoBaseSize * clampedScale),
+                            contentAlignment = Alignment.Center
+                        ) {
                             Box(homeContentModifier, contentAlignment = Alignment.Center) {
                                 LogoImage()
                             }
                         }
                     }
                     item {
-                        Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                        // Reserve scaled height for the search bar
+                        Box(
+                            Modifier.fillMaxWidth().height(searchBarBaseHeight * clampedScale),
+                            contentAlignment = Alignment.Center
+                        ) {
                             Box(homeContentModifier) {
                                 // In REFERENCE mode, repurpose the first TextField as the predictive
                             // Book picker (with Category/Book suggestions). Enter should NOT open.


### PR DESCRIPTION
## Summary
- Scale top padding and item spacing proportionally with the zoom level
- Reserve actual layout space for scaled logo and search bar heights
- Prevent logo from being cropped at the top when zooming
- Prevent logo from overlapping with the search bar when zooming

## Root cause
The `graphicsLayer` transformation is visual-only and doesn't affect layout bounds. When zooming, the logo visually grows but the layout still allocates the original unscaled dimensions, causing visual overflow.

## Test plan
- [ ] Zoom in on the Home view and verify the logo doesn't get cropped at the top
- [ ] Zoom in and verify adequate spacing is maintained between the logo and search bar
- [ ] Zoom out and verify layout remains correct at smaller scales