### PR TITLE
Increase Shulchan Aruch dropdown popup height

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/components/CatalogRow.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/components/CatalogRow.kt
@@ -111,7 +111,7 @@ fun CatalogRow(
                         spec = PrecomputedCatalog.Dropdowns.SHULCHAN_ARUCH,
                         onEvent = onEvent,
                         modifier = Modifier.widthIn(max = buttonWidth),
-                        maxPopupHeight = 130.dp,
+                        maxPopupHeight = 160.dp,
                         popupWidthMultiplier = 1.1f
                     )
                 }


### PR DESCRIPTION
## Summary
- Increase `maxPopupHeight` from 130.dp to 160.dp for the Shulchan Aruch catalog dropdown
- Improves visibility of menu items in the dropdown

## Test plan
- [x] Open the book content view
- [x] Click on the Shulchan Aruch dropdown
- [x] Verify the popup height is adequate to display menu items
