### PR TITLE
Replace info banners with expandable chevron in SettingCard

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/ExpandCollapseIcon.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/ExpandCollapseIcon.kt
@@ -1,0 +1,39 @@
+package io.github.kdroidfilter.seforimapp.core.presentation.components
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.github.kdroidfilter.seforimapp.icons.ChevronDown
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Icon
+
+/**
+ * Animated chevron icon that points down when collapsed and up when expanded.
+ * Uses rotation animation for smooth transition.
+ */
+@Composable
+fun ExpandCollapseIcon(
+    expanded: Boolean,
+    modifier: Modifier = Modifier,
+    size: Dp = 12.dp,
+    tint: Color = JewelTheme.globalColors.text.normal,
+    contentDescription: String? = null
+) {
+    val rotation by animateFloatAsState(
+        targetValue = if (expanded) 180f else 0f,
+        label = "chevron_rotation"
+    )
+
+    Icon(
+        ChevronDown,
+        contentDescription = contentDescription,
+        modifier = (if (modifier == Modifier) Modifier.size(size) else modifier).rotate(rotation),
+        tint = tint
+    )
+}

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/GeneralSettingsScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/GeneralSettingsScreen.kt
@@ -1,5 +1,6 @@
 package io.github.kdroidfilter.seforimapp.features.settings.ui
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -31,6 +32,7 @@ import io.github.kdroidfilter.seforimapp.core.presentation.utils.LocalWindowView
 import io.github.kdroidfilter.seforimapp.features.settings.general.GeneralSettingsEvents
 import io.github.kdroidfilter.seforimapp.features.settings.general.GeneralSettingsState
 import io.github.kdroidfilter.seforimapp.features.settings.general.GeneralSettingsViewModel
+import io.github.kdroidfilter.seforimapp.core.presentation.components.ExpandCollapseIcon
 import io.github.kdroidfilter.seforimapp.theme.PreviewContainer
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.painterResource
@@ -232,6 +234,7 @@ private fun SettingCard(
     onCheckedChange: (Boolean) -> Unit
 ) {
     val shape = RoundedCornerShape(8.dp)
+    var expanded by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -240,23 +243,39 @@ private fun SettingCard(
             .border(1.dp, JewelTheme.globalColors.borders.normal, shape)
             .background(JewelTheme.globalColors.panelBackground)
             .padding(12.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        InlineInformationBanner(
-            style = JewelTheme.inlineBannerStyle.information,
-            text = stringResource(description),
-        )
-
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            Checkbox(
-                checked = checked,
-                onCheckedChange = onCheckedChange
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Checkbox(
+                    checked = checked,
+                    onCheckedChange = onCheckedChange
+                )
+                Text(text = stringResource(title))
+            }
+
+            IconButton(
+                onClick = { expanded = !expanded },
+                modifier = Modifier.size(24.dp)
+            ) {
+                ExpandCollapseIcon(expanded = expanded, size = 16.dp)
+            }
+        }
+
+        AnimatedVisibility(visible = expanded) {
+            Text(
+                text = stringResource(description),
+                fontSize = 12.sp,
+                color = JewelTheme.globalColors.text.info,
+                modifier = Modifier.padding(start = 28.dp)
             )
-            Text(text = stringResource(title))
         }
     }
 }
@@ -278,18 +297,6 @@ private fun ResetSection(
             .padding(12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        if (resetDone) {
-            InlineWarningBanner(
-                style = JewelTheme.inlineBannerStyle.warning,
-                text = stringResource(Res.string.settings_reset_done),
-            )
-        } else {
-            InlineWarningBanner(
-                style = JewelTheme.inlineBannerStyle.warning,
-                text = stringResource(Res.string.settings_reset_warning),
-            )
-        }
-
         if (showConfirmation) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -313,6 +320,18 @@ private fun ResetSection(
             DefaultButton(onClick = { showConfirmation = true }) {
                 Text(text = stringResource(Res.string.settings_reset_app))
             }
+        }
+
+        if (resetDone) {
+            InlineWarningBanner(
+                style = JewelTheme.inlineBannerStyle.warning,
+                text = stringResource(Res.string.settings_reset_done),
+            )
+        } else {
+            InlineWarningBanner(
+                style = JewelTheme.inlineBannerStyle.warning,
+                text = stringResource(Res.string.settings_reset_warning),
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add new `ExpandCollapseIcon` component with smooth rotation animation (ChevronDown rotates 180° when expanded)
- Replace `InlineInformationBanner` in `SettingCard` with a clickable chevron that expands to show the description text
- Move `InlineWarningBanner` below the button in `ResetSection`

## Test plan
- [x] Verify SettingCard displays chevron arrow on the right
- [x] Verify clicking chevron expands/collapses the description with animation
- [x] Verify ResetSection warning banner appears below the reset button