### PR TITLE
Fix installer splash screen DPI alignment

### DIFF
--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -10,6 +10,7 @@ authors = ["KDroidFilter"]
 windows = { version = "0.58", features = [
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_HiDpi",
     "Win32_Graphics_Gdi",
     "Win32_System_LibraryLoader",
     "Win32_System_Threading",


### PR DESCRIPTION
## Summary
- Add DPI awareness (`PER_MONITOR_AWARE_V2`) before window creation to handle high-DPI displays
- Use negative `biHeight` for top-down DIB format (aligned with JetBrains Runtime approach)
- Remove unnecessary manual vertical flip of pixel data

## Test plan
- [ ] Test on Windows with 100% display scale
- [ ] Test on Windows with 125%/150% display scale
- [ ] Verify splash image displays at correct size in all cases
