### PR TITLE
Auto-focus tab content on activation for keyboard navigation

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsNavHost.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsNavHost.kt
@@ -328,6 +328,7 @@ fun TabsNavHost() {
                                 isRestoringSession = isRestoringSession,
                                 searchUi = searchUi,
                                 searchCallbacks = homeSearchCallbacks,
+                                isSelected = isSelected,
                             )
                         }
                         nonAnimatedComposable<TabsDestination.Search> { backStackEntry ->
@@ -457,6 +458,7 @@ fun TabsNavHost() {
                                 isRestoringSession = isRestoringSession,
                                 searchUi = searchUi,
                                 searchCallbacks = homeSearchCallbacks,
+                                isSelected = isSelected,
                             )
                         }
                 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/BookContentScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/BookContentScreen.kt
@@ -252,6 +252,7 @@ fun BookContentScreen(
     isRestoringSession: Boolean = false,
     searchUi: SearchHomeUiState,
     searchCallbacks: HomeSearchCallbacks,
+    isSelected: Boolean = true,
 ) {
     // Toaster for transient messages (e.g., selection limits)
     val toaster = rememberToasterState()
@@ -449,7 +450,8 @@ fun BookContentScreen(
                                 showDiacritics = showDiacritics,
                                 isRestoringSession = isRestoringSession,
                                 searchUi = searchUi,
-                                searchCallbacks = searchCallbacks
+                                searchCallbacks = searchCallbacks,
+                                isSelected = isSelected
                             )
                         },
                         showSplitter = uiState.toc.isVisible

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/BookContentPanel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/BookContentPanel.kt
@@ -43,7 +43,7 @@ fun BookContentPanel(
     modifier: Modifier = Modifier,
     isRestoringSession: Boolean = false,
     searchUi: SearchHomeUiState = SearchHomeUiState(),
-        searchCallbacks: HomeSearchCallbacks = HomeSearchCallbacks(
+    searchCallbacks: HomeSearchCallbacks = HomeSearchCallbacks(
         onReferenceQueryChanged = {},
         onTocQueryChanged = {},
         onFilterChange = {},
@@ -53,7 +53,8 @@ fun BookContentPanel(
         onPickCategory = {},
         onPickBook = {},
         onPickToc = {}
-    )
+    ),
+    isSelected: Boolean = true
 ) {
 
     // Preserve LazyListState across recompositions.
@@ -149,7 +150,8 @@ fun BookContentPanel(
                             altHeadingsByLineId = uiState.altToc.lineHeadingsByLineId,
                             lineConnections = connectionsCache,
                             onPrefetchLineConnections = prefetchConnections,
-                            showDiacritics = showDiacritics
+                            showDiacritics = showDiacritics,
+                            isSelected = isSelected
                         )
                     },
                     secondContent = if (uiState.content.showTargum) {

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BookContentView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BookContentView.kt
@@ -84,7 +84,8 @@ fun BookContentView(
     altHeadingsByLineId: Map<Long, List<AltTocEntry>> = emptyMap(),
     lineConnections: Map<Long, LineConnectionsSnapshot> = emptyMap(),
     onPrefetchLineConnections: (List<Long>) -> Unit = {},
-    showDiacritics: Boolean
+    showDiacritics: Boolean,
+    isSelected: Boolean = true
 ) {
     // Collect paging data
     val lazyPagingItems: LazyPagingItems<Line> = linesPagingData.collectAsLazyPagingItems()
@@ -433,6 +434,12 @@ fun BookContentView(
     LaunchedEffect(book.id) { focusRequester.requestFocus() }
     LaunchedEffect(showFind) {
         if (!showFind) {
+            focusRequester.requestFocus()
+        }
+    }
+    // Request focus when tab becomes selected for immediate keyboard navigation
+    LaunchedEffect(isSelected) {
+        if (isSelected) {
             focusRequester.requestFocus()
         }
     }


### PR DESCRIPTION
## Summary
- When a tab is activated (by clicking its header or using Ctrl+Tab), the book content area now automatically receives focus
- This allows immediate keyboard navigation with arrow keys without requiring an additional click

## Changes
- Added `isSelected` parameter to `BookContentView`, `BookContentPanel`, and `BookContentScreen`
- Added `LaunchedEffect(isSelected)` in `BookContentView` that requests focus when tab becomes selected
- Passed `isSelected` from `TabsNavHost` in classic mode

Fix #245 