### PR TITLE
Change font preview text to avoid divine name

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/FontsSettingsScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/FontsSettingsScreen.kt
@@ -53,7 +53,7 @@ fun FontsSettingsScreen() {
     FontsSettingsView(state = state, onEvent = viewModel::onEvent)
 }
 
-private const val PREVIEW_TEXT = "בְּרֵאשִׁית בָּרָא אֱלֹהִים אֵת הַשָּׁמַיִם וְאֵת הָאָרֶץ"
+private const val PREVIEW_TEXT = "דּוֹר הֹלֵךְ וְדוֹר בָּא וְהָאָרֶץ לְעוֹלָם עֹמָדֶת"
 
 @Composable
 private fun FontsSettingsView(state: FontsSettingsState, onEvent: (FontsSettingsEvents) -> Unit) {


### PR DESCRIPTION
## Summary
- Replace Genesis 1:1 with Ecclesiastes 1:4 for the font preview text in settings
- The new text "דּוֹר הֹלֵךְ וְדוֹר בָּא וְהָאָרֶץ לְעוֹלָם עֹמָדֶת" does not contain the divine name

Fixes #249