### PR TITLE
Fix Community enum being optimized by ProGuard

### DIFF
--- a/SeforimApp/proguard-rules.pro
+++ b/SeforimApp/proguard-rules.pro
@@ -234,3 +234,8 @@
 -keep class com.kosherjava.zmanim.** { *; }
 -keep enum com.kosherjava.zmanim.** { *; }
 -dontwarn com.kosherjava.zmanim.**
+
+# --- Fix: Community enum used with valueOf() for Kiddush Levana opinion selection ---
+# The Community enum is resolved at runtime via Enum.valueOf(code) where code is stored
+# in AppSettings. If R8/ProGuard optimizes or unboxes this enum, valueOf() will fail.
+-keep enum io.github.kdroidfilter.seforimapp.features.onboarding.userprofile.Community { *; }


### PR DESCRIPTION
## Summary
- Added ProGuard keep rule for the `Community` enum used in Kiddush Levana opinion selection
- The enum is resolved at runtime via `Enum.valueOf()` and was failing silently when ProGuard optimized it

## Test plan
- [x] Build release version with ProGuard enabled
- [x] Verify Kiddush Levana opinions change correctly based on user community (SEPHARADE vs others)