### PR TITLE
Add OpenGL rendering option for Windows users

### DIFF
--- a/SeforimApp/src/commonMain/composeResources/values/strings.xml
+++ b/SeforimApp/src/commonMain/composeResources/values/strings.xml
@@ -283,6 +283,8 @@
     <string name="settings_persist_session_description">כאשר אפשרות זו מופעלת, האפליקציה תשמור את הלשוניות הפתוחות ומיקום הקריאה שלך, ותשחזר אותם בהפעלה הבאה.</string>
     <string name="settings_show_zmanim_widgets">הצג זמנים הלכתיים בדף הבית</string>
     <string name="settings_show_zmanim_widgets_description">כאשר אפשרות זו מופעלת, יוצגו בדף הבית וידג'טים עם זמני היום ההלכתיים (נץ החמה, שקיעה, זמני תפילה וכו').</string>
+    <string name="settings_use_opengl">השתמש ב-OpenGL במקום DirectX</string>
+    <string name="settings_use_opengl_description">הפעל אפשרות זו רק אם אתה נתקל בבעיות תצוגה עם DirectX, כגון הבהובים או ריצודים במסך. שינוי זה יחול לאחר הפעלה מחדש של היישום.</string>
 
     <!-- Onboarding -->
     <string name="onboarding_title_bar">מדריך ההגדרה של זית</string>

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/settings/AppSettings.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/settings/AppSettings.kt
@@ -73,6 +73,9 @@ object AppSettings {
     // Zmanim widgets visibility
     private const val KEY_SHOW_ZMANIM_WIDGETS = "show_zmanim_widgets"
 
+    // Rendering backend (Windows only)
+    private const val KEY_USE_OPENGL = "use_opengl"
+
     // Backing Settings storage (can be replaced at startup if needed)
     @Volatile
     private var settings: Settings = Settings()
@@ -290,6 +293,15 @@ object AppSettings {
     fun setShowZmanimWidgetsEnabled(enabled: Boolean) {
         settings[KEY_SHOW_ZMANIM_WIDGETS] = enabled
         _showZmanimWidgetsFlow.value = enabled
+    }
+
+    // OpenGL rendering backend (Windows only)
+    fun isUseOpenGlEnabled(): Boolean {
+        return settings[KEY_USE_OPENGL, false]
+    }
+
+    fun setUseOpenGlEnabled(enabled: Boolean) {
+        settings[KEY_USE_OPENGL] = enabled
     }
 
     // RAM saver setting

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/general/GeneralSettingsEvents.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/general/GeneralSettingsEvents.kt
@@ -4,5 +4,6 @@ sealed interface GeneralSettingsEvents {
     data class SetCloseTreeOnNewBook(val value: Boolean) : GeneralSettingsEvents
     data class SetPersistSession(val value: Boolean) : GeneralSettingsEvents
     data class SetShowZmanimWidgets(val value: Boolean) : GeneralSettingsEvents
+    data class SetUseOpenGl(val value: Boolean) : GeneralSettingsEvents
     data object ResetApp : GeneralSettingsEvents
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/general/GeneralSettingsState.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/general/GeneralSettingsState.kt
@@ -8,6 +8,7 @@ data class GeneralSettingsState(
     val closeTreeOnNewBook: Boolean = false,
     val persistSession: Boolean = true,
     val showZmanimWidgets: Boolean = true,
+    val useOpenGl: Boolean = false,
     val resetDone: Boolean = false,
 ) {
     companion object {
@@ -16,6 +17,7 @@ data class GeneralSettingsState(
             closeTreeOnNewBook = true,
             persistSession = true,
             showZmanimWidgets = true,
+            useOpenGl = false,
             resetDone = false,
         )
     }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/general/GeneralSettingsViewModel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/general/GeneralSettingsViewModel.kt
@@ -26,16 +26,19 @@ class GeneralSettingsViewModel : ViewModel() {
     private val closeTree = MutableStateFlow(AppSettings.getCloseBookTreeOnNewBookSelected())
     private val persist = MutableStateFlow(AppSettings.isPersistSessionEnabled())
     private val showZmanim = MutableStateFlow(AppSettings.isShowZmanimWidgetsEnabled())
+    private val useOpenGl = MutableStateFlow(AppSettings.isUseOpenGlEnabled())
     private val resetDone = MutableStateFlow(false)
 
     val state = combine(
-        dbPath, closeTree, persist, showZmanim, resetDone
-    ) { path, c, p, z, r ->
+        combine(dbPath, closeTree, persist) { path, c, p -> Triple(path, c, p) },
+        combine(showZmanim, useOpenGl, resetDone) { z, gl, r -> Triple(z, gl, r) }
+    ) { (path, c, p), (z, gl, r) ->
         GeneralSettingsState(
             databasePath = path,
             closeTreeOnNewBook = c,
             persistSession = p,
             showZmanimWidgets = z,
+            useOpenGl = gl,
             resetDone = r
         )
     }.stateIn(
@@ -46,6 +49,7 @@ class GeneralSettingsViewModel : ViewModel() {
             closeTreeOnNewBook = closeTree.value,
             persistSession = persist.value,
             showZmanimWidgets = showZmanim.value,
+            useOpenGl = useOpenGl.value,
             resetDone = resetDone.value,
         )
     )
@@ -63,6 +67,10 @@ class GeneralSettingsViewModel : ViewModel() {
             is GeneralSettingsEvents.SetShowZmanimWidgets -> {
                 AppSettings.setShowZmanimWidgetsEnabled(event.value)
                 showZmanim.value = event.value
+            }
+            is GeneralSettingsEvents.SetUseOpenGl -> {
+                AppSettings.setUseOpenGlEnabled(event.value)
+                useOpenGl.value = event.value
             }
             is GeneralSettingsEvents.ResetApp -> {
                 // Get the databases directory

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/GeneralSettingsScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/GeneralSettingsScreen.kt
@@ -27,7 +27,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.zacsweers.metrox.viewmodel.metroViewModel
+import io.github.kdroidfilter.platformtools.OperatingSystem
 import io.github.kdroidfilter.platformtools.getAppVersion
+import io.github.kdroidfilter.platformtools.getOperatingSystem
 import io.github.kdroidfilter.seforimapp.core.presentation.utils.LocalWindowViewModelStoreOwner
 import io.github.kdroidfilter.seforimapp.features.settings.general.GeneralSettingsEvents
 import io.github.kdroidfilter.seforimapp.features.settings.general.GeneralSettingsState
@@ -69,6 +71,8 @@ import seforimapp.seforimapp.generated.resources.settings_reset_confirm_no
 import seforimapp.seforimapp.generated.resources.settings_reset_confirm_yes
 import seforimapp.seforimapp.generated.resources.settings_reset_done
 import seforimapp.seforimapp.generated.resources.settings_reset_warning
+import seforimapp.seforimapp.generated.resources.settings_use_opengl
+import seforimapp.seforimapp.generated.resources.settings_use_opengl_description
 import seforimapp.seforimapp.generated.resources.update_available_banner
 import seforimapp.seforimapp.generated.resources.update_download_action
 
@@ -118,6 +122,16 @@ private fun GeneralSettingsView(
                 checked = state.showZmanimWidgets,
                 onCheckedChange = { onEvent(GeneralSettingsEvents.SetShowZmanimWidgets(it)) }
             )
+
+            // OpenGL setting - Windows only
+            if (getOperatingSystem() == OperatingSystem.WINDOWS) {
+                SettingCard(
+                    title = Res.string.settings_use_opengl,
+                    description = Res.string.settings_use_opengl_description,
+                    checked = state.useOpenGl,
+                    onCheckedChange = { onEvent(GeneralSettingsEvents.SetUseOpenGl(it)) }
+                )
+            }
 
             ResetSection(
                 resetDone = state.resetDone,

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/main.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/main.kt
@@ -80,6 +80,11 @@ import java.net.URI
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalTrayAppApi::class)
 fun main() {
+    // Force OpenGL rendering backend on Windows if enabled (must be set before Skia initialization)
+    if (getOperatingSystem() == OperatingSystem.WINDOWS && AppSettings.isUseOpenGlEnabled()) {
+        System.setProperty("skiko.renderApi", "OPENGL")
+    }
+
     setMacOsAdaptiveTitleBar()
 
     // Register global AWT key event dispatcher for Cmd+Shift+C (copy without nikud)


### PR DESCRIPTION
## Summary
- Add a new setting in General settings to use OpenGL instead of DirectX on Windows
- This option is only visible on Windows platform
- Useful for users experiencing display issues with DirectX (flickering, screen tearing, etc.)
- The setting requires an application restart to take effect

## Changes
- `AppSettings.kt`: Added `use_opengl` setting key and getter/setter functions
- `GeneralSettingsState.kt`: Added `useOpenGl` field
- `GeneralSettingsEvents.kt`: Added `SetUseOpenGl` event
- `GeneralSettingsViewModel.kt`: Added handler for the new event
- `GeneralSettingsScreen.kt`: Added conditional UI (Windows only)
- `main.kt`: Apply `System.setProperty("skiko.renderApi", "OPENGL")` at startup if enabled
- `strings.xml`: Added Hebrew strings for the setting

## Test plan
- [x] Verify the setting appears only on Windows
- [x] Verify the setting persists after app restart
- [x] Verify OpenGL is used when the setting is enabled (check with graphics debugging tools)
- [x] Verify DirectX is used when the setting is disabled (default behavior)