### PR TITLE
הקטנת ה DP בשולי הכפתורים במסך הבית כדי לאפשר הצגת שולחן ערוך

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/components/CatalogRow.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/components/CatalogRow.kt
@@ -30,7 +30,7 @@ fun CatalogRow(
         modifier = Modifier
             .fillMaxSize()
             .zIndex(1f)
-            .padding(16.dp),
+            .padding(6.dp),
         contentAlignment = Alignment.TopStart
     ) {
 


### PR DESCRIPTION
כרגע אצלי למרות שיש לי מסך יחסית רחב [14"]
לא מוצג הכפתור/טאב 'שולחן ערוך' במסך הבית.
וזה מפריע כי ה'שולחן ערוך' הוא מאוד שימושי.

זה קורה בגלל שיש שוליים שנחתכים מגודל המסך עוד לפני חישוב כמות הפתורים שיכולים להיכנס,

הורדתי את הכמות מ 16 ל 6.

(בין כך כרגע הוווידג'ט של 'זמני היום' הוא ממש צמוד לצדדים בלי padding בכלל)

מקווה שתאשר.....