### PR TITLE
fix: update download URL to /download path

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/update/AppUpdateChecker.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/update/AppUpdateChecker.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.withContext
  */
 object AppUpdateChecker {
 
-    const val DOWNLOAD_URL = "https://kdroidfilter.github.io/Zayit/"
+    const val DOWNLOAD_URL = "https://kdroidfilter.github.io/Zayit/download"
 
     private val releaseFetcher = GitHubReleaseFetcher(
         owner = "kdroidFilter",


### PR DESCRIPTION
## Summary
- Update the download URL in AppUpdateChecker to point to `/download` path

This aligns with the new website structure where the main site is at root and the download page is at `/download`.