### PR TITLE
refactor: clean up SearchHomeViewModel dependencies

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/di/modules/AppCoreBindings.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/di/modules/AppCoreBindings.kt
@@ -106,17 +106,13 @@ object AppCoreBindings {
     @Provides
     @SingleIn(AppScope::class)
     fun provideSearchHomeViewModel(
-        tabsViewModel: TabsViewModel,
         persistedStore: TabPersistedStateStore,
         repository: SeforimRepository,
-        searchEngine: SearchEngine,
         lookup: LuceneLookupSearchService,
         settings: Settings
     ): SearchHomeViewModel = SearchHomeViewModel(
-        tabsViewModel = tabsViewModel,
         persistedStore = persistedStore,
         repository = repository,
-        searchEngine = searchEngine,
         lookup = lookup,
         settings = settings
     )


### PR DESCRIPTION
## Summary
- Remove `TabsViewModel` dependency from `SearchHomeViewModel`
- Remove unused `SearchEngine` dependency
- Extract navigation logic to UI layer using event-based pattern

## Changes

### SearchHomeViewModel
- Added `SearchHomeNavigationEvent` sealed class with `NavigateToSearch` and `NavigateToBookContent`
- Navigation is now emitted as events via a Channel/Flow instead of calling `tabsViewModel.replaceCurrentTabDestination()` directly
- `submitSearch(query)` → `submitSearch(query, currentTabId)` 
- `openSelectedReferenceInCurrentTab()` → `openSelectedReferenceInCurrentTab(currentTabId)`
- Added `dismissSuggestions()` method for UI to call when navigating away from Home
- Removed observation of tab changes (moved to UI layer)

### TabsNavHost
- Collects `navigationEvents` from ViewModel and performs actual navigation
- Observes tab changes and calls `dismissSuggestions()` when leaving Home
- Provides `currentTabId` to callbacks via `derivedStateOf`

### AppCoreBindings
- Simplified `provideSearchHomeViewModel()` - removed `tabsViewModel` and `searchEngine` parameters

## Benefits
- Better separation of concerns (ViewModel emits intents, UI navigates)
- Improved testability (ViewModel can be tested without navigation mocks)
- Removed dead code (`searchEngine` was never used)

## Test plan
- [x] Compilation passes
- [x] Unit tests pass
- [x] Manual testing: search from Home screen
- [x] Manual testing: open reference from Home screen
- [x] Verify suggestions dismiss when changing tabs