### PR TITLE
refactor: cache platform info to avoid repeated OS detection

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/MainTitleBar.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/MainTitleBar.kt
@@ -8,8 +8,8 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.github.kdroidfilter.platformtools.OperatingSystem
-import io.github.kdroidfilter.platformtools.getOperatingSystem
 import io.github.kdroidfilter.seforimapp.core.presentation.tabs.TabsView
+import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import org.jetbrains.jewel.window.DecoratedWindowScope
 import org.jetbrains.jewel.window.TitleBar
 import org.jetbrains.jewel.window.newFullscreenControls
@@ -28,7 +28,7 @@ fun DecoratedWindowScope.MainTitleBar() {
             // This avoids subtle 1px oscillations on small or non-integer window sizes.
             val tabsAreaWidth: Dp = with(density) {
                 val windowWidthPx = windowWidth.toPx()
-                val iconsAreaWidthDp = when (getOperatingSystem()) {
+                val iconsAreaWidthDp = when (PlatformInfo.currentOS) {
                     OperatingSystem.MACOS -> iconWidth * (iconsNumber + 2)
                     OperatingSystem.WINDOWS -> iconWidth * (iconsNumber + 3.5f)
                     else -> iconWidth * iconsNumber

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/TitleBarActionsButtonsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/TitleBarActionsButtonsView.kt
@@ -6,9 +6,8 @@ import dev.zacsweers.metrox.viewmodel.metroViewModel
 import io.github.kdroidfilter.seforim.tabs.TabsDestination
 import io.github.kdroidfilter.seforim.tabs.TabsViewModel
 import io.github.kdroidfilter.seforimapp.core.MainAppState
-import io.github.kdroidfilter.platformtools.OperatingSystem
-import io.github.kdroidfilter.platformtools.getOperatingSystem
 import io.github.kdroidfilter.seforimapp.core.presentation.theme.IntUiThemes
+import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import io.github.kdroidfilter.seforimapp.core.presentation.utils.LocalWindowViewModelStoreOwner
 import io.github.kdroidfilter.seforimapp.core.settings.AppSettings
 import io.github.kdroidfilter.seforimapp.features.settings.SettingsWindow
@@ -54,15 +53,15 @@ fun TitleBarActionsButtonsView() {
         IntUiThemes.System -> stringResource(Res.string.switch_to_light_theme)
     }
 
-    val homeShortcutHint = if (getOperatingSystem() == OperatingSystem.MACOS)
+    val homeShortcutHint = if (PlatformInfo.isMacOS)
         stringResource(Res.string.shortcut_home_mac)
     else stringResource(Res.string.shortcut_home_windows)
 
-    val findShortcutHint = if (getOperatingSystem() == OperatingSystem.MACOS)
+    val findShortcutHint = if (PlatformInfo.isMacOS)
         stringResource(Res.string.shortcut_find_mac)
     else stringResource(Res.string.shortcut_find_windows)
 
-    val settingsShortcutHint = if (getOperatingSystem() == OperatingSystem.MACOS)
+    val settingsShortcutHint = if (PlatformInfo.isMacOS)
         stringResource(Res.string.shortcut_settings_mac)
     else stringResource(Res.string.shortcut_settings_windows)
 

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsView.kt
@@ -43,9 +43,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
-import io.github.kdroidfilter.platformtools.OperatingSystem
-import io.github.kdroidfilter.platformtools.getOperatingSystem
 import io.github.kdroidfilter.seforim.tabs.*
+import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import io.github.kdroidfilter.seforimapp.core.presentation.components.TitleBarActionButton
 import io.github.kdroidfilter.seforimapp.core.presentation.theme.AppColors
 import io.github.kdroidfilter.seforimapp.core.settings.AppSettings
@@ -442,8 +441,7 @@ private fun RtlAwareTabStripContent(
                 color = JewelTheme.globalColors.borders.disabled
             )
 
-            val os = getOperatingSystem()
-            val shortcutHint = if (os == OperatingSystem.MACOS) "⌘+T" else "Ctrl+T"
+            val shortcutHint = if (PlatformInfo.isMacOS) "⌘+T" else "Ctrl+T"
             TitleBarActionButton(
                 onClick = onAddClick,
                 key = AllIconsKeys.General.Add,

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/components/VerticalBars.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/components/VerticalBars.kt
@@ -4,9 +4,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
-import io.github.kdroidfilter.platformtools.OperatingSystem
-import io.github.kdroidfilter.platformtools.getOperatingSystem
 import io.github.kdroidfilter.seforimapp.core.presentation.components.SelectableIconButtonWithToolip
+import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import io.github.kdroidfilter.seforimapp.core.presentation.components.VerticalLateralBar
 import io.github.kdroidfilter.seforimapp.core.presentation.components.VerticalLateralBarPosition
 import io.github.kdroidfilter.seforimapp.core.settings.AppSettings
@@ -31,7 +30,7 @@ fun StartVerticalBar(
                 icon = Library,
                 iconDescription = stringResource(Res.string.books),
                 label = stringResource(Res.string.books),
-                shortcutHint = if (getOperatingSystem() == OperatingSystem.MACOS) "B+⌘" else "B+Ctrl"
+                shortcutHint = if (PlatformInfo.isMacOS) "B+⌘" else "B+Ctrl"
             )
             SelectableIconButtonWithToolip(
                 toolTipText = stringResource(Res.string.book_content),
@@ -40,7 +39,7 @@ fun StartVerticalBar(
                 icon = TableOfContents,
                 iconDescription = stringResource(Res.string.table_of_contents),
                 label = stringResource(Res.string.table_of_contents),
-                shortcutHint = if (getOperatingSystem() == OperatingSystem.MACOS) "B+⇧+⌘" else "B+Shift+Ctrl"
+                shortcutHint = if (PlatformInfo.isMacOS) "B+⇧+⌘" else "B+Shift+Ctrl"
 
             )
         },
@@ -134,7 +133,7 @@ fun EndVerticalBar(
                 icon = ZoomIn,
                 iconDescription = stringResource(Res.string.zoom_in),
                 label = stringResource(Res.string.zoom_in),
-                shortcutHint = if (getOperatingSystem() == OperatingSystem.MACOS) "+⌘" else "+Ctrl"
+                shortcutHint = if (PlatformInfo.isMacOS) "+⌘" else "+Ctrl"
             )
             SelectableIconButtonWithToolip(
                 toolTipText = if (canZoomOut)
@@ -147,7 +146,7 @@ fun EndVerticalBar(
                 icon = ZoomOut,
                 iconDescription = stringResource(Res.string.zoom_out),
                 label = stringResource(Res.string.zoom_out),
-                shortcutHint = if (getOperatingSystem() == OperatingSystem.MACOS) "-⌘" else "-Ctrl"
+                shortcutHint = if (PlatformInfo.isMacOS) "-⌘" else "-Ctrl"
             )
 
             // Diacritics toggle button - only show when book has nekudot or teamim
@@ -163,7 +162,7 @@ fun EndVerticalBar(
                     icon = TextDiacritics,
                     iconDescription = stringResource(Res.string.toggle_diacritics),
                     label = stringResource(Res.string.toggle_diacritics),
-                    shortcutHint = if (getOperatingSystem() == OperatingSystem.MACOS) "J+⌘" else "J+Ctrl"
+                    shortcutHint = if (PlatformInfo.isMacOS) "J+⌘" else "J+Ctrl"
                 )
             }
 //            SelectableIconButtonWithToolip(
@@ -222,7 +221,7 @@ fun EndVerticalBar(
                         iconDescription = stringResource(Res.string.show_targumim),
                         label = stringResource(Res.string.show_targumim),
                         enabled = !targumDisabledForLine,
-                        shortcutHint = if (getOperatingSystem() == OperatingSystem.MACOS) "K+⇧+⌘" else "K+Shift+Ctrl"
+                        shortcutHint = if (PlatformInfo.isMacOS) "K+⇧+⌘" else "K+Shift+Ctrl"
                     )
                 }
 
@@ -235,7 +234,7 @@ fun EndVerticalBar(
                         iconDescription = stringResource(Res.string.show_sources),
                         label = stringResource(Res.string.show_sources),
                         enabled = !sourcesDisabledForLine,
-                        shortcutHint = if (getOperatingSystem() == OperatingSystem.MACOS) "K+⌥+⌘" else "K+Alt+Ctrl"
+                        shortcutHint = if (PlatformInfo.isMacOS) "K+⌥+⌘" else "K+Alt+Ctrl"
                     )
                 }
 
@@ -249,7 +248,7 @@ fun EndVerticalBar(
                         iconDescription = stringResource(Res.string.show_commentaries),
                         label = stringResource(Res.string.show_commentaries),
                         enabled = !commentaryDisabledForLine,
-                        shortcutHint = if (getOperatingSystem() == OperatingSystem.MACOS) "K+⌘" else "K+Ctrl"
+                        shortcutHint = if (PlatformInfo.isMacOS) "K+⌘" else "K+Ctrl"
                     )
                 }
             }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BookContentView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BookContentView.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.input.key.*
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.isPrimaryPressed
 import androidx.compose.ui.input.pointer.isShiftPressed
+import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
@@ -122,9 +123,8 @@ fun BookContentView(
     val hebrewFontFamily = FontCatalog.familyFor(bookFontCode)
     // macOS fallback: some Hebrew fonts have no Bold face; slightly scale bold text for visibility
     val boldScaleForPlatform = remember(bookFontCode) {
-        val isMac = System.getProperty("os.name")?.contains("Mac", ignoreCase = true) == true
         val lacksBold = bookFontCode in setOf("notoserifhebrew", "notorashihebrew", "frankruhllibre")
-        if (isMac && lacksBold) 1.08f else 1.0f
+        if (PlatformInfo.isMacOS && lacksBold) 1.08f else 1.0f
     }
 
     // Track restoration state per book

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
@@ -38,6 +38,7 @@ import io.github.kdroidfilter.seforimapp.core.presentation.components.Horizontal
 import io.github.kdroidfilter.seforimapp.core.presentation.text.highlightAnnotated
 import io.github.kdroidfilter.seforimapp.core.presentation.typography.FontCatalog
 import io.github.kdroidfilter.seforimapp.core.settings.AppSettings
+import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import io.github.kdroidfilter.seforimapp.features.bookcontent.BookContentEvent
 import io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookContentState
 import io.github.kdroidfilter.seforimapp.features.bookcontent.state.CommentatorGroup
@@ -320,9 +321,8 @@ private fun CommentariesDisplay(
     val commentaryFontCode by AppSettings.commentaryFontCodeFlow.collectAsState()
     val commentaryFontFamily = FontCatalog.familyFor(commentaryFontCode)
     val boldScaleForPlatform = remember(commentaryFontCode) {
-        val isMac = System.getProperty("os.name")?.contains("Mac", ignoreCase = true) == true
         val lacksBold = commentaryFontCode in setOf("notoserifhebrew", "notorashihebrew", "frankruhllibre")
-        if (isMac && lacksBold) 1.08f else 1.0f
+        if (PlatformInfo.isMacOS && lacksBold) 1.08f else 1.0f
     }
 
     val layoutConfig = remember(

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineTargumView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineTargumView.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.input.pointer.isCtrlPressed
 import androidx.compose.ui.input.pointer.isMetaPressed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalWindowInfo
+import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -90,9 +91,8 @@ fun LineTargumView(
     val targumFontCode by fontCodeFlow.collectAsState()
     val targumFontFamily = FontCatalog.familyFor(targumFontCode)
     val boldScaleForPlatform = remember(targumFontCode) {
-        val isMac = System.getProperty("os.name")?.contains("Mac", ignoreCase = true) == true
         val lacksBold = targumFontCode in setOf("notoserifhebrew", "notorashihebrew", "frankruhllibre")
-        if (isMac && lacksBold) 1.08f else 1.0f
+        if (PlatformInfo.isMacOS && lacksBold) 1.08f else 1.0f
     }
 
     val paneInteractionSource = remember { MutableInteractionSource() }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/database/update/DatabaseUpdateWindow.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/database/update/DatabaseUpdateWindow.kt
@@ -11,9 +11,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ApplicationScope
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.navigation.compose.rememberNavController
-import io.github.kdroidfilter.platformtools.OperatingSystem
-import io.github.kdroidfilter.platformtools.getOperatingSystem
 import io.github.kdroidfilter.seforimapp.core.presentation.utils.getCenteredWindowState
+import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import io.github.kdroidfilter.seforimapp.core.presentation.utils.LocalWindowViewModelStoreOwner
 import io.github.kdroidfilter.seforimapp.core.presentation.utils.rememberWindowViewModelStoreOwner
 import io.github.kdroidfilter.seforimapp.features.database.update.navigation.DatabaseUpdateNavHost
@@ -43,7 +42,7 @@ fun ApplicationScope.DatabaseUpdateWindow(
     DecoratedWindow(
         onCloseRequest = { exitApplication() },
         title = stringResource(Res.string.app_name),
-        icon = if (getOperatingSystem() == OperatingSystem.MACOS) null else painterResource(Res.drawable.AppIcon),
+        icon = if (PlatformInfo.isMacOS) null else painterResource(Res.drawable.AppIcon),
         state = updateWindowState,
         visible = true,
         resizable = false,
@@ -62,8 +61,8 @@ fun ApplicationScope.DatabaseUpdateWindow(
             LocalWindowViewModelStoreOwner provides windowViewModelOwner,
             LocalViewModelStoreOwner provides windowViewModelOwner,
         ) {
-            val isMac = getOperatingSystem() == OperatingSystem.MACOS
-            val isWindows = getOperatingSystem() == OperatingSystem.WINDOWS
+            val isMac = PlatformInfo.isMacOS
+            val isWindows = PlatformInfo.isWindows
             val navController = rememberNavController()
             var canNavigateBack by remember { mutableStateOf(false) }
 

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/onboarding/OnBoardingWindow.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/onboarding/OnBoardingWindow.kt
@@ -25,9 +25,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ApplicationScope
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.navigation.compose.rememberNavController
-import io.github.kdroidfilter.platformtools.OperatingSystem
-import io.github.kdroidfilter.platformtools.getOperatingSystem
 import io.github.kdroidfilter.seforimapp.core.presentation.utils.getCenteredWindowState
+import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import io.github.kdroidfilter.seforimapp.core.presentation.utils.LocalWindowViewModelStoreOwner
 import io.github.kdroidfilter.seforimapp.core.presentation.utils.rememberWindowViewModelStoreOwner
 import io.github.kdroidfilter.seforimapp.features.onboarding.navigation.OnBoardingNavHost
@@ -55,7 +54,7 @@ fun ApplicationScope.OnBoardingWindow() {
     DecoratedWindow(
         onCloseRequest = { exitApplication() },
         title = stringResource(Res.string.app_name),
-        icon = if (getOperatingSystem() == OperatingSystem.MACOS) null else painterResource(  Res.drawable.AppIcon),
+        icon = if (PlatformInfo.isMacOS) null else painterResource(Res.drawable.AppIcon),
         state = onboardingWindowState,
         visible = true,
         resizable = false,
@@ -74,8 +73,8 @@ fun ApplicationScope.OnBoardingWindow() {
             LocalWindowViewModelStoreOwner provides windowViewModelOwner,
             LocalViewModelStoreOwner provides windowViewModelOwner,
         ) {
-            val isMac = getOperatingSystem() == OperatingSystem.MACOS
-            val isWindows = getOperatingSystem() == OperatingSystem.WINDOWS
+            val isMac = PlatformInfo.isMacOS
+            val isWindows = PlatformInfo.isWindows
             val navController = rememberNavController()
             var canNavigateBack by remember { mutableStateOf(false) }
             LaunchedEffect(navController) {

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchResultScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchResultScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.input.pointer.isCtrlPressed
 import androidx.compose.ui.input.pointer.isMetaPressed
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.platform.LocalWindowInfo
+import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -583,9 +584,8 @@ private fun SearchResultItemGoogleStyle(
     // On macOS, some Hebrew fonts in our catalog don't include bold faces.
     // Apply a subtle boldScale to keep emphasis visible on those fonts.
     val boldScaleForPlatform = remember(bookFontCode) {
-        val isMac = System.getProperty("os.name")?.contains("Mac", ignoreCase = true) == true
         val lacksBold = bookFontCode in setOf("notoserifhebrew", "notorashihebrew", "frankruhllibre")
-        if (isMac && lacksBold) 1.08f else 1.0f
+        if (PlatformInfo.isMacOS && lacksBold) 1.08f else 1.0f
     }
     val boldColor = JewelTheme.globalColors.outlines.focused
     val annotated: AnnotatedString = remember(result.snippet, textSize, boldScaleForPlatform, boldColor) {

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/SettingsWindow.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/SettingsWindow.kt
@@ -15,9 +15,8 @@ import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.rememberWindowState
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.navigation.compose.rememberNavController
-import io.github.kdroidfilter.platformtools.OperatingSystem
-import io.github.kdroidfilter.platformtools.getOperatingSystem
 import io.github.kdroidfilter.seforimapp.core.presentation.theme.ThemeUtils
+import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import io.github.kdroidfilter.seforimapp.core.presentation.theme.ThemeUtils.buildThemeDefinition
 import io.github.kdroidfilter.seforimapp.core.presentation.utils.LocalWindowViewModelStoreOwner
 import io.github.kdroidfilter.seforimapp.core.presentation.utils.rememberWindowViewModelStoreOwner
@@ -76,8 +75,8 @@ private fun SettingsWindowView(
                 LocalWindowViewModelStoreOwner provides windowViewModelOwner,
                 LocalViewModelStoreOwner provides windowViewModelOwner,
             ) {
-                val isMac = getOperatingSystem() == OperatingSystem.MACOS
-                val isWindows = getOperatingSystem() == OperatingSystem.WINDOWS
+                val isMac = PlatformInfo.isMacOS
+                val isWindows = PlatformInfo.isWindows
                 TitleBar(modifier = Modifier.newFullscreenControls()) {
                     Box(
                         modifier = Modifier.fillMaxWidth(if (isMac) 0.9f else 1f)

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/GeneralSettingsScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/GeneralSettingsScreen.kt
@@ -27,10 +27,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.zacsweers.metrox.viewmodel.metroViewModel
-import io.github.kdroidfilter.platformtools.OperatingSystem
 import io.github.kdroidfilter.platformtools.getAppVersion
-import io.github.kdroidfilter.platformtools.getOperatingSystem
 import io.github.kdroidfilter.seforimapp.core.presentation.utils.LocalWindowViewModelStoreOwner
+import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import io.github.kdroidfilter.seforimapp.features.settings.general.GeneralSettingsEvents
 import io.github.kdroidfilter.seforimapp.features.settings.general.GeneralSettingsState
 import io.github.kdroidfilter.seforimapp.features.settings.general.GeneralSettingsViewModel
@@ -124,7 +123,7 @@ private fun GeneralSettingsView(
             )
 
             // OpenGL setting - Windows only
-            if (getOperatingSystem() == OperatingSystem.WINDOWS) {
+            if (PlatformInfo.isWindows) {
                 SettingCard(
                     title = Res.string.settings_use_opengl,
                     description = Res.string.settings_use_opengl_description,

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/platform/PlatformInfo.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/platform/PlatformInfo.kt
@@ -1,0 +1,30 @@
+package io.github.kdroidfilter.seforimapp.framework.platform
+
+import io.github.kdroidfilter.platformtools.OperatingSystem
+import io.github.kdroidfilter.platformtools.getOperatingSystem
+
+/**
+ * Cached platform information.
+ * Values are computed once at class loading time and reused throughout the application lifecycle.
+ */
+object PlatformInfo {
+    /**
+     * The current operating system, cached at startup.
+     */
+    val currentOS: OperatingSystem = getOperatingSystem()
+
+    /**
+     * True if running on macOS.
+     */
+    val isMacOS: Boolean = currentOS == OperatingSystem.MACOS
+
+    /**
+     * True if running on Windows.
+     */
+    val isWindows: Boolean = currentOS == OperatingSystem.WINDOWS
+
+    /**
+     * True if running on Linux.
+     */
+    val isLinux: Boolean = currentOS == OperatingSystem.LINUX
+}

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/update/AppUpdateChecker.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/update/AppUpdateChecker.kt
@@ -1,9 +1,8 @@
 package io.github.kdroidfilter.seforimapp.framework.update
 
-import io.github.kdroidfilter.platformtools.OperatingSystem
 import io.github.kdroidfilter.platformtools.getAppVersion
-import io.github.kdroidfilter.platformtools.getOperatingSystem
 import io.github.kdroidfilter.platformtools.releasefetcher.github.GitHubReleaseFetcher
+import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import io.github.kdroidfilter.seforimapp.network.KtorConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -74,7 +73,7 @@ object AppUpdateChecker {
         val normalized = version.trim()
 
         // On macOS, convert 1.x.y back to 0.x.y (reverse of macSafeVersion in build.gradle.kts)
-        if (getOperatingSystem() == OperatingSystem.MACOS) {
+        if (PlatformInfo.isMacOS) {
             val parts = normalized.split(".")
             if (parts.isNotEmpty() && parts[0] == "1") {
                 return "0.${parts.drop(1).joinToString(".")}"

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/main.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/main.kt
@@ -18,7 +18,7 @@ import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
 import dev.zacsweers.metrox.viewmodel.metroViewModel
 import io.github.kdroidfilter.platformtools.OperatingSystem
 import io.github.kdroidfilter.platformtools.darkmodedetector.mac.setMacOsAdaptiveTitleBar
-import io.github.kdroidfilter.platformtools.getOperatingSystem
+import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import io.github.kdroidfilter.seforim.tabs.TabType
 import io.github.kdroidfilter.seforimapp.core.MainAppState
 import io.github.kdroidfilter.seforimapp.core.presentation.components.MainTitleBar
@@ -81,7 +81,7 @@ import java.net.URI
 @OptIn(ExperimentalFoundationApi::class, ExperimentalTrayAppApi::class)
 fun main() {
     // Force OpenGL rendering backend on Windows if enabled (must be set before Skia initialization)
-    if (getOperatingSystem() == OperatingSystem.WINDOWS && AppSettings.isUseOpenGlEnabled()) {
+    if (PlatformInfo.isWindows && AppSettings.isUseOpenGlEnabled()) {
         System.setProperty("skiko.renderApi", "OPENGL")
     }
 
@@ -118,7 +118,7 @@ fun main() {
         FileKit.init(appId)
 
         val screen = Toolkit.getDefaultToolkit().screenSize
-        val windowState = if (getOperatingSystem() != OperatingSystem.WINDOWS) rememberWindowState(
+        val windowState = if (!PlatformInfo.isWindows) rememberWindowState(
             position = WindowPosition.Aligned(Alignment.Center),
             placement = WindowPlacement.Maximized,
             size = DpSize(screen.width.dp, screen.height.dp)
@@ -251,7 +251,7 @@ fun main() {
                             exitApplication()
                         },
                         title = windowTitle,
-                        icon = if (getOperatingSystem() == OperatingSystem.MACOS) null else painterResource(  Res.drawable.AppIcon),
+                        icon = if (PlatformInfo.isMacOS) null else painterResource(Res.drawable.AppIcon),
                         state = windowState,
                         visible = isWindowVisible,
                         onKeyEvent = { keyEvent ->
@@ -287,7 +287,7 @@ fun main() {
                                     // Open settings with Cmd+, or Ctrl+,
                                     settingsWindowViewModel.onEvent(SettingsWindowEvents.onOpen)
                                     true
-                                } else if (getOperatingSystem() == OperatingSystem.MACOS && keyEvent.isMetaPressed && keyEvent.key == Key.M) {
+                                } else if (PlatformInfo.isMacOS && keyEvent.isMetaPressed && keyEvent.key == Key.M) {
                                     // Minimize window with Cmd+M on macOS
                                     windowState.isMinimized = true
                                     true
@@ -318,7 +318,7 @@ fun main() {
 
                             LaunchedEffect(Unit) {
                                 window.minimumSize = Dimension(600, 300)
-                                if (getOperatingSystem() == OperatingSystem.WINDOWS) {
+                                if (PlatformInfo.isWindows) {
                                     delay(10)
                                     windowState.placement = WindowPlacement.Maximized
                                 }
@@ -423,7 +423,7 @@ fun main() {
                                                     true
                                                 }
                                                 // Cmd + M => minimize window (macOS only)
-                                                getOperatingSystem() == OperatingSystem.MACOS && keyEvent.isMetaPressed && keyEvent.key == Key.M -> {
+                                                PlatformInfo.isMacOS && keyEvent.isMetaPressed && keyEvent.key == Key.M -> {
                                                     windowState.isMinimized = true
                                                     true
                                                 }


### PR DESCRIPTION
## Summary
- Add `PlatformInfo` singleton that caches OS type at startup
- Replace all `getOperatingSystem()` calls with `PlatformInfo` properties (`isMacOS`, `isWindows`, `isLinux`, `currentOS`)
- Replace direct `System.getProperty("os.name")` checks with `PlatformInfo.isMacOS`

## Problem
The operating system was being detected multiple times throughout the codebase via `getOperatingSystem()` calls, which is unnecessary since the OS doesn't change during runtime.

## Solution
Created a `PlatformInfo` singleton object that:
- Computes the OS type once at class loading time
- Exposes convenient boolean properties (`isMacOS`, `isWindows`, `isLinux`)
- Exposes the full `OperatingSystem` enum value via `currentOS`

## Files changed
- **New**: `framework/platform/PlatformInfo.kt` - Cached platform info singleton
- **Updated**: 14 files to use `PlatformInfo` instead of `getOperatingSystem()` or `System.getProperty()`