### PR TITLE
feat(jewel): add DecoratedDialog for modal windows with JBR decorations

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/SettingsWindow.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/SettingsWindow.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.WindowPosition
-import androidx.compose.ui.window.rememberWindowState
+import androidx.compose.ui.window.rememberDialogState
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.navigation.compose.rememberNavController
 import io.github.kdroidfilter.seforimapp.core.presentation.theme.ThemeUtils
@@ -32,8 +32,8 @@ import org.jetbrains.jewel.ui.ComponentStyling
 import org.jetbrains.jewel.ui.Orientation
 import org.jetbrains.jewel.ui.component.*
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
-import org.jetbrains.jewel.window.DecoratedWindow
-import org.jetbrains.jewel.window.TitleBar
+import org.jetbrains.jewel.window.DecoratedDialog
+import org.jetbrains.jewel.window.DialogTitleBar
 import org.jetbrains.jewel.window.newFullscreenControls
 import seforimapp.seforimapp.generated.resources.*
 
@@ -55,12 +55,12 @@ private fun SettingsWindowView(onClose: () -> Unit) {
                 titleBarStyle = ThemeUtils.pickTitleBarStyle(),
             ),
     ) {
-        val settingsWindowState = rememberWindowState(position = WindowPosition.Aligned(Alignment.Center), size = DpSize(700.dp, 500.dp))
-        DecoratedWindow(
+        val settingsDialogState = rememberDialogState(position = WindowPosition.Aligned(Alignment.Center), size = DpSize(700.dp, 500.dp))
+        DecoratedDialog(
             onCloseRequest = onClose,
             title = stringResource(Res.string.settings),
             icon = painterResource(Res.drawable.AppIcon),
-            state = settingsWindowState,
+            state = settingsDialogState,
             visible = true,
             resizable = true,
         ) {
@@ -74,7 +74,7 @@ private fun SettingsWindowView(onClose: () -> Unit) {
             ) {
                 val isMac = PlatformInfo.isMacOS
                 val isWindows = PlatformInfo.isWindows
-                TitleBar(modifier = Modifier.newFullscreenControls()) {
+                DialogTitleBar(modifier = Modifier.newFullscreenControls()) {
                     Box(
                         modifier =
                             Modifier

--- a/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/DecoratedDialog.kt
+++ b/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/DecoratedDialog.kt
@@ -1,0 +1,297 @@
+package org.jetbrains.jewel.window
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposeDialog
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.offset
+import androidx.compose.ui.window.DialogState
+import androidx.compose.ui.window.DialogWindow
+import androidx.compose.ui.window.DialogWindowScope
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.rememberDialogState
+import com.jetbrains.JBR
+import org.jetbrains.jewel.foundation.Stroke
+import org.jetbrains.jewel.foundation.modifier.border
+import org.jetbrains.jewel.foundation.modifier.trackWindowActivation
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.window.styling.DecoratedWindowStyle
+import org.jetbrains.jewel.window.utils.DesktopPlatform
+import java.awt.event.ComponentEvent
+import java.awt.event.ComponentListener
+import java.awt.event.WindowAdapter
+import java.awt.event.WindowEvent
+
+/**
+ * A decorated modal dialog that uses JetBrains Runtime (JBR) for native window decorations.
+ *
+ * Unlike [DecoratedWindow], this dialog:
+ * - Is modal (blocks the parent window)
+ * - Has a simplified title bar with only a close button (no minimize/maximize)
+ * - Cannot be minimized, maximized, or made fullscreen
+ *
+ * @param onCloseRequest Called when the user requests to close the dialog
+ * @param state The dialog state controlling position and size
+ * @param visible Whether the dialog is visible
+ * @param title The dialog title displayed in the title bar
+ * @param icon The dialog icon
+ * @param resizable Whether the dialog can be resized (default: false)
+ * @param enabled Whether the dialog is enabled for input
+ * @param focusable Whether the dialog can receive focus
+ * @param onPreviewKeyEvent Called before key events are handled
+ * @param onKeyEvent Called when key events are handled
+ * @param style The visual style for the dialog
+ * @param content The dialog content, receives [DecoratedDialogScope]
+ */
+@Composable
+public fun DecoratedDialog(
+    onCloseRequest: () -> Unit,
+    state: DialogState = rememberDialogState(
+        position = WindowPosition.PlatformDefault,
+        size = DpSize.Unspecified,
+    ),
+    visible: Boolean = true,
+    title: String = "",
+    icon: Painter? = null,
+    resizable: Boolean = false,
+    enabled: Boolean = true,
+    focusable: Boolean = true,
+    onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
+    onKeyEvent: (KeyEvent) -> Boolean = { false },
+    style: DecoratedWindowStyle = JewelTheme.defaultDecoratedWindowStyle,
+    content: @Composable DecoratedDialogScope.() -> Unit,
+) {
+    remember {
+        if (!JBR.isAvailable()) {
+            error(
+                "DecoratedDialog can only be used on JetBrainsRuntime(JBR) platform, " +
+                    "please check the document https://github.com/JetBrains/jewel#int-ui-standalone-theme",
+            )
+        }
+    }
+
+    // Using undecorated window for linux
+    val undecorated = DesktopPlatform.Linux == DesktopPlatform.Current
+
+    DialogWindow(
+        onCloseRequest = onCloseRequest,
+        state = state,
+        visible = visible,
+        title = title,
+        icon = icon,
+        undecorated = undecorated,
+        transparent = false,
+        resizable = resizable,
+        enabled = enabled,
+        focusable = focusable,
+        onPreviewKeyEvent = onPreviewKeyEvent,
+        onKeyEvent = onKeyEvent,
+    ) {
+        var decoratedDialogState by remember { mutableStateOf(DecoratedDialogState.of(window)) }
+
+        DisposableEffect(window) {
+            val adapter =
+                object : WindowAdapter(), ComponentListener {
+                    override fun windowActivated(e: WindowEvent?) {
+                        decoratedDialogState = DecoratedDialogState.of(window)
+                    }
+
+                    override fun windowDeactivated(e: WindowEvent?) {
+                        decoratedDialogState = DecoratedDialogState.of(window)
+                    }
+
+                    override fun componentResized(e: ComponentEvent?) {
+                        decoratedDialogState = DecoratedDialogState.of(window)
+                    }
+
+                    override fun componentMoved(e: ComponentEvent?) {
+                        // Empty
+                    }
+
+                    override fun componentShown(e: ComponentEvent?) {
+                        // Empty
+                    }
+
+                    override fun componentHidden(e: ComponentEvent?) {
+                        // Empty
+                    }
+                }
+
+            window.addWindowListener(adapter)
+            window.addComponentListener(adapter)
+
+            onDispose {
+                window.removeWindowListener(adapter)
+                window.removeComponentListener(adapter)
+            }
+        }
+
+        val undecoratedWindowBorder =
+            if (undecorated) {
+                Modifier
+                    .border(
+                        Stroke.Alignment.Inside,
+                        style.metrics.borderWidth,
+                        style.colors.borderFor(decoratedDialogState.toDecoratedWindowState()).value,
+                        RectangleShape,
+                    ).padding(style.metrics.borderWidth)
+            } else {
+                Modifier
+            }
+
+        CompositionLocalProvider(LocalDialogTitleBarInfo provides DialogTitleBarInfo(title, icon)) {
+            Layout(
+                content = {
+                    val scope =
+                        object : DecoratedDialogScope {
+                            override val state: DecoratedDialogState
+                                get() = decoratedDialogState
+
+                            override val window: ComposeDialog
+                                get() = this@DialogWindow.window
+                        }
+                    scope.content()
+                },
+                modifier = undecoratedWindowBorder.trackWindowActivation(window),
+                measurePolicy = DecoratedDialogMeasurePolicy,
+            )
+        }
+    }
+}
+
+/**
+ * Scope for the content of a [DecoratedDialog].
+ */
+@Stable
+public interface DecoratedDialogScope : DialogWindowScope {
+    override val window: ComposeDialog
+
+    public val state: DecoratedDialogState
+}
+
+private object DecoratedDialogMeasurePolicy : MeasurePolicy {
+    override fun MeasureScope.measure(
+        measurables: List<Measurable>,
+        constraints: Constraints,
+    ): MeasureResult {
+        if (measurables.isEmpty()) {
+            return layout(width = constraints.minWidth, height = constraints.minHeight) {}
+        }
+
+        val titleBars = measurables.filter { it.layoutId == DIALOG_TITLE_BAR_LAYOUT_ID }
+        if (titleBars.size > 1) {
+            error("Dialog can have only one title bar")
+        }
+        val titleBar = titleBars.firstOrNull()
+        val titleBarBorder = measurables.firstOrNull { it.layoutId == DIALOG_TITLE_BAR_BORDER_LAYOUT_ID }
+
+        val contentConstraints = constraints.copy(minWidth = 0, minHeight = 0)
+
+        val titleBarPlaceable = titleBar?.measure(contentConstraints)
+        val titleBarHeight = titleBarPlaceable?.height ?: 0
+
+        val titleBarBorderPlaceable = titleBarBorder?.measure(contentConstraints)
+        val titleBarBorderHeight = titleBarBorderPlaceable?.height ?: 0
+
+        val measuredPlaceable = mutableListOf<Placeable>()
+
+        for (it in measurables) {
+            if (it.layoutId.toString().startsWith(DIALOG_TITLE_BAR_COMPONENT_LAYOUT_ID_PREFIX)) continue
+            val offsetConstraints = contentConstraints.offset(vertical = -titleBarHeight - titleBarBorderHeight)
+            val placeable = it.measure(offsetConstraints)
+            measuredPlaceable += placeable
+        }
+
+        return layout(constraints.maxWidth, constraints.maxHeight) {
+            titleBarPlaceable?.placeRelative(0, 0)
+            titleBarBorderPlaceable?.placeRelative(0, titleBarHeight)
+
+            measuredPlaceable.forEach { it.placeRelative(0, titleBarHeight + titleBarBorderHeight) }
+        }
+    }
+}
+
+/**
+ * State of a [DecoratedDialog].
+ *
+ * Unlike [DecoratedWindowState], this only tracks the active state since dialogs
+ * cannot be minimized, maximized, or made fullscreen.
+ */
+@Immutable
+@JvmInline
+public value class DecoratedDialogState(
+    public val state: ULong,
+) {
+    public val isActive: Boolean
+        get() = state and Active != 0UL
+
+    public fun copy(
+        active: Boolean = isActive,
+    ): DecoratedDialogState = of(active = active)
+
+    /**
+     * Converts this dialog state to a [DecoratedWindowState] for compatibility
+     * with shared styling APIs.
+     */
+    public fun toDecoratedWindowState(): DecoratedWindowState =
+        DecoratedWindowState.of(
+            fullscreen = false,
+            minimized = false,
+            maximized = false,
+            active = isActive,
+        )
+
+    override fun toString(): String = "${javaClass.simpleName}(isActive=$isActive)"
+
+    public companion object {
+        public val Active: ULong = 1UL shl 0
+
+        public fun of(
+            active: Boolean = true,
+        ): DecoratedDialogState =
+            DecoratedDialogState(
+                if (active) Active else 0UL,
+            )
+
+        public fun of(window: ComposeDialog): DecoratedDialogState =
+            of(active = window.isActive)
+    }
+}
+
+internal data class DialogTitleBarInfo(
+    val title: String,
+    val icon: Painter?,
+)
+
+internal val LocalDialogTitleBarInfo: ProvidableCompositionLocal<DialogTitleBarInfo> =
+    compositionLocalOf {
+        error("LocalDialogTitleBarInfo not provided, DialogTitleBar must be used in DecoratedDialog")
+    }
+
+internal const val DIALOG_TITLE_BAR_COMPONENT_LAYOUT_ID_PREFIX = "__DIALOG_TITLE_BAR_"
+
+internal const val DIALOG_TITLE_BAR_LAYOUT_ID = "__DIALOG_TITLE_BAR_CONTENT__"
+
+internal const val DIALOG_TITLE_BAR_BORDER_LAYOUT_ID = "__DIALOG_TITLE_BAR_BORDER__"

--- a/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/DialogTitleBar.Linux.kt
+++ b/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/DialogTitleBar.Linux.kt
@@ -1,0 +1,47 @@
+package org.jetbrains.jewel.window
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.unit.dp
+import com.jetbrains.JBR
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.window.styling.TitleBarStyle
+import org.jetbrains.jewel.window.utils.DialogCloseButton
+import java.awt.event.MouseEvent
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+internal fun DecoratedDialogScope.DialogTitleBarOnLinux(
+    modifier: Modifier = Modifier,
+    gradientStartColor: Color = Color.Unspecified,
+    style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
+    content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit,
+) {
+    val linuxStyle = createLinuxTitleBarStyle(style)
+    val dialogState = state
+
+    DialogTitleBarImpl(
+        modifier.onPointerEvent(PointerEventType.Press, PointerEventPass.Main) {
+            if (
+                this.currentEvent.button == PointerButton.Primary &&
+                this.currentEvent.changes.any { changed -> !changed.isConsumed }
+            ) {
+                JBR.getWindowMove()?.startMovingTogetherWithMouse(window, MouseEvent.BUTTON1)
+            }
+        },
+        gradientStartColor,
+        linuxStyle,
+        { _, _ -> PaddingValues(0.dp) },
+    ) { _ ->
+        // Dialog only shows close button (no minimize/maximize)
+        DialogCloseButton(window, dialogState, linuxStyle, iconHoveredEffect = true)
+        content(dialogState)
+    }
+}

--- a/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/DialogTitleBar.MacOS.kt
+++ b/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/DialogTitleBar.MacOS.kt
@@ -1,0 +1,33 @@
+package org.jetbrains.jewel.window
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.jetbrains.JBR
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.window.styling.TitleBarStyle
+
+@Composable
+internal fun DecoratedDialogScope.DialogTitleBarOnMacOs(
+    modifier: Modifier = Modifier,
+    gradientStartColor: Color = Color.Unspecified,
+    style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
+    content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit,
+) {
+    val titleBar = remember { JBR.getWindowDecorations().createCustomTitleBar() }
+
+    DialogTitleBarImpl(
+        modifier = modifier.customTitleBarMouseEventHandler(titleBar),
+        gradientStartColor = gradientStartColor,
+        style = style,
+        applyTitleBar = { height, _ ->
+            titleBar.height = height.value
+            JBR.getWindowDecorations().setCustomTitleBar(window, titleBar)
+            PaddingValues(start = titleBar.leftInset.dp, end = titleBar.rightInset.dp)
+        },
+        content = content,
+    )
+}

--- a/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/DialogTitleBar.Windows.kt
+++ b/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/DialogTitleBar.Windows.kt
@@ -1,0 +1,40 @@
+package org.jetbrains.jewel.window
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import com.jetbrains.JBR
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.window.styling.TitleBarStyle
+
+@Composable
+internal fun DecoratedDialogScope.DialogTitleBarOnWindows(
+    modifier: Modifier = Modifier,
+    gradientStartColor: Color = Color.Unspecified,
+    style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
+    content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit,
+) {
+    val titleBar = remember { JBR.getWindowDecorations().createCustomTitleBar() }
+    val layoutDirection = LocalLayoutDirection.current
+
+    DialogTitleBarImpl(
+        modifier = modifier.customTitleBarMouseEventHandler(titleBar),
+        gradientStartColor = gradientStartColor,
+        style = style,
+        applyTitleBar = { height, _ ->
+            titleBar.height = height.value
+            JBR.getWindowDecorations().setCustomTitleBar(window, titleBar)
+            if (layoutDirection == LayoutDirection.Ltr) {
+                PaddingValues(start = titleBar.leftInset.dp, end = titleBar.rightInset.dp)
+            } else {
+                PaddingValues(start = titleBar.rightInset.dp, end = titleBar.leftInset.dp)
+            }
+        },
+        content = content,
+    )
+}

--- a/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/DialogTitleBar.kt
+++ b/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/DialogTitleBar.kt
@@ -1,0 +1,66 @@
+package org.jetbrains.jewel.window
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.window.styling.TitleBarStyle
+import org.jetbrains.jewel.window.utils.DesktopPlatform
+
+/**
+ * A title bar for [DecoratedDialog] windows.
+ *
+ * This reuses the same [TitleBarScope] as the regular [TitleBar], but is designed
+ * for modal dialog windows (no minimize/maximize buttons on Linux).
+ *
+ * @param modifier Modifier to apply to the title bar
+ * @param gradientStartColor Optional gradient start color for the background
+ * @param style The visual style for the title bar
+ * @param content The title bar content, receives [TitleBarScope]
+ */
+@Composable
+public fun DecoratedDialogScope.DialogTitleBar(
+    modifier: Modifier = Modifier,
+    gradientStartColor: Color = Color.Unspecified,
+    style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
+    content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit,
+) {
+    // Provide title bar info for the scope
+    val titleBarInfo = LocalDialogTitleBarInfo.current
+    CompositionLocalProvider(
+        LocalTitleBarInfo provides TitleBarInfo(titleBarInfo.title, titleBarInfo.icon),
+    ) {
+        when (DesktopPlatform.Current) {
+            DesktopPlatform.Linux -> DialogTitleBarOnLinux(modifier, gradientStartColor, style, content)
+            DesktopPlatform.Windows -> DialogTitleBarOnWindows(modifier, gradientStartColor, style, content)
+            DesktopPlatform.MacOS -> DialogTitleBarOnMacOs(modifier, gradientStartColor, style, content)
+            DesktopPlatform.Unknown -> error("DialogTitleBar is not supported on this platform(${System.getProperty("os.name")})")
+        }
+    }
+}
+
+@Composable
+internal fun DecoratedDialogScope.DialogTitleBarImpl(
+    modifier: Modifier = Modifier,
+    gradientStartColor: Color = Color.Unspecified,
+    style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
+    applyTitleBar: (Dp, DecoratedWindowState) -> PaddingValues,
+    content: @Composable TitleBarScope.(DecoratedDialogState) -> Unit,
+) {
+    val dialogState = state
+    // Delegate to the common TitleBarImpl by wrapping the content
+    GenericTitleBarImpl(
+        window = window,
+        state = dialogState.toDecoratedWindowState(),
+        modifier = modifier,
+        gradientStartColor = gradientStartColor,
+        style = style,
+        applyTitleBar = applyTitleBar,
+    ) { windowState ->
+        // Call user content with dialog state instead of window state
+        content(dialogState)
+    }
+}

--- a/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/TitleBar.Linux.kt
+++ b/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/TitleBar.Linux.kt
@@ -22,15 +22,12 @@ import org.jetbrains.jewel.window.utils.linux.LinuxTitleBarIconsFactory
 import java.awt.Frame
 import java.awt.event.MouseEvent
 
-@OptIn(ExperimentalComposeUiApi::class)
+/**
+ * Creates a Linux-specific title bar style with appropriate icons and transparent button backgrounds.
+ * This is shared between TitleBar and DialogTitleBar on Linux.
+ */
 @Composable
-internal fun DecoratedWindowScope.TitleBarOnLinux(
-    modifier: Modifier = Modifier,
-    gradientStartColor: Color = Color.Unspecified,
-    style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
-    content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
-) {
-    // Replace icons with the ones appropriate for the current Linux DE
+internal fun createLinuxTitleBarStyle(style: TitleBarStyle): TitleBarStyle {
     val linuxIconButtonStyle =
         IconButtonStyle(
             colors =
@@ -55,31 +52,41 @@ internal fun DecoratedWindowScope.TitleBarOnLinux(
         )
 
     val linuxIcons = LinuxTitleBarIconsFactory.createForCurrentDesktop()
-    val linuxStyle =
-        TitleBarStyle(
-            colors =
-                TitleBarColors(
-                    background = style.colors.background,
-                    inactiveBackground = style.colors.inactiveBackground,
-                    content = style.colors.content,
-                    border = style.colors.border,
-                    fullscreenControlButtonsBackground = style.colors.fullscreenControlButtonsBackground,
-                    titlePaneButtonHoveredBackground = style.colors.titlePaneButtonHoveredBackground,
-                    titlePaneButtonPressedBackground = style.colors.titlePaneButtonPressedBackground,
-                    titlePaneCloseButtonHoveredBackground = Color.Transparent,
-                    titlePaneCloseButtonPressedBackground = Color.Transparent,
-                    iconButtonHoveredBackground = style.colors.iconButtonHoveredBackground,
-                    iconButtonPressedBackground = style.colors.iconButtonPressedBackground,
-                    dropdownPressedBackground = style.colors.dropdownPressedBackground,
-                    dropdownHoveredBackground = style.colors.dropdownHoveredBackground,
-                ),
-            metrics = style.metrics,
-            icons = linuxIcons,
-            dropdownStyle = style.dropdownStyle,
-            iconButtonStyle = style.iconButtonStyle,
-            paneButtonStyle = linuxIconButtonStyle,
-            paneCloseButtonStyle = linuxIconButtonStyle,
-        )
+    return TitleBarStyle(
+        colors =
+            TitleBarColors(
+                background = style.colors.background,
+                inactiveBackground = style.colors.inactiveBackground,
+                content = style.colors.content,
+                border = style.colors.border,
+                fullscreenControlButtonsBackground = style.colors.fullscreenControlButtonsBackground,
+                titlePaneButtonHoveredBackground = style.colors.titlePaneButtonHoveredBackground,
+                titlePaneButtonPressedBackground = style.colors.titlePaneButtonPressedBackground,
+                titlePaneCloseButtonHoveredBackground = Color.Transparent,
+                titlePaneCloseButtonPressedBackground = Color.Transparent,
+                iconButtonHoveredBackground = style.colors.iconButtonHoveredBackground,
+                iconButtonPressedBackground = style.colors.iconButtonPressedBackground,
+                dropdownPressedBackground = style.colors.dropdownPressedBackground,
+                dropdownHoveredBackground = style.colors.dropdownHoveredBackground,
+            ),
+        metrics = style.metrics,
+        icons = linuxIcons,
+        dropdownStyle = style.dropdownStyle,
+        iconButtonStyle = style.iconButtonStyle,
+        paneButtonStyle = linuxIconButtonStyle,
+        paneCloseButtonStyle = linuxIconButtonStyle,
+    )
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+internal fun DecoratedWindowScope.TitleBarOnLinux(
+    modifier: Modifier = Modifier,
+    gradientStartColor: Color = Color.Unspecified,
+    style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
+    content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
+) {
+    val linuxStyle = createLinuxTitleBarStyle(style)
 
     var lastPress = 0L
     val viewConfig = LocalViewConfiguration.current

--- a/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/TitleBar.kt
+++ b/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/TitleBar.kt
@@ -58,6 +58,33 @@ internal fun DecoratedWindowScope.TitleBarImpl(
     backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
 ) {
+    GenericTitleBarImpl(
+        window = window,
+        state = state,
+        modifier = modifier,
+        gradientStartColor = gradientStartColor,
+        style = style,
+        applyTitleBar = applyTitleBar,
+        backgroundContent = backgroundContent,
+        content = content,
+    )
+}
+
+/**
+ * Generic title bar implementation that can be used by both [DecoratedWindow] and [DecoratedDialog].
+ * This avoids code duplication between TitleBar and DialogTitleBar.
+ */
+@Composable
+internal fun GenericTitleBarImpl(
+    window: Window,
+    state: DecoratedWindowState,
+    modifier: Modifier = Modifier,
+    gradientStartColor: Color = Color.Unspecified,
+    style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
+    applyTitleBar: (Dp, DecoratedWindowState) -> PaddingValues,
+    backgroundContent: @Composable () -> Unit = {},
+    content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
+) {
     val titleBarInfo = LocalTitleBarInfo.current
 
     val background by style.colors.backgroundFor(state)

--- a/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/utils/WindowControlArea.kt
+++ b/jewel/src/jvmMain/kotlin/org/jetbrains/jewel/window/utils/WindowControlArea.kt
@@ -26,6 +26,7 @@ import org.jetbrains.jewel.ui.icon.IconKey
 import org.jetbrains.jewel.ui.painter.PainterHint
 import org.jetbrains.jewel.ui.painter.PainterProviderScope
 import org.jetbrains.jewel.ui.painter.PainterSuffixHint
+import org.jetbrains.jewel.window.DecoratedDialogState
 import org.jetbrains.jewel.window.DecoratedWindowState
 import org.jetbrains.jewel.window.TitleBarScope
 import org.jetbrains.jewel.window.defaultTitleBarStyle
@@ -125,5 +126,29 @@ internal fun TitleBarScope.WindowControlArea(
         iconHoveredEffect = iconHoveredEffect,
         style = style,
         iconButtonStyle = style.paneButtonStyle,
+    )
+}
+
+/**
+ * Close button for dialog title bars.
+ * Unlike [WindowControlArea], this only shows the close button (no minimize/maximize).
+ * Uses [TitleBarScope] for consistency with the regular title bar.
+ */
+@Composable
+internal fun TitleBarScope.DialogCloseButton(
+    window: java.awt.Window,
+    state: DecoratedDialogState,
+    style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
+    iconHoveredEffect: Boolean = false,
+) {
+    // Reuse ControlButton by converting dialog state to window state
+    ControlButton(
+        onClick = { window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING)) },
+        state = state.toDecoratedWindowState(),
+        iconKey = style.icons.closeButton,
+        description = "Close",
+        style = style,
+        iconButtonStyle = style.paneCloseButtonStyle,
+        iconHoveredEffect = iconHoveredEffect,
     )
 }


### PR DESCRIPTION
## Summary
- Add `DecoratedDialog` component that combines modal behavior with JBR title bar decorations
- Add `DialogTitleBar` with platform-specific implementations (MacOS, Windows, Linux)
- Refactor `TitleBar` to share code and avoid duplication
- Update `SettingsWindow` to use `DecoratedDialog`

## Details

### New Components
- **DecoratedDialog**: Modal dialog using `DialogWindow` with JBR decorations
- **DialogTitleBar**: Title bar with close button only (no minimize/maximize)
- **DecoratedDialogState**: Simplified state (only `isActive`, no fullscreen/minimize/maximize)

### Code Sharing
- `GenericTitleBarImpl`: Shared implementation for both Window and Dialog title bars
- `createLinuxTitleBarStyle`: Reusable Linux-specific styling
- `DialogCloseButton`: Reuses `ControlButton` via state conversion

## Test plan
- [ ] Test SettingsWindow opens as modal dialog
- [ ] Verify title bar decorations work on macOS/Windows/Linux
- [ ] Verify only close button appears (no minimize/maximize)
- [ ] Test dialog blocks parent window interaction