### PR TITLE
fix(settings): use verse with taamim in font preview

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/FontsSettingsScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/FontsSettingsScreen.kt
@@ -53,7 +53,7 @@ fun FontsSettingsScreen() {
     FontsSettingsView(state = state, onEvent = viewModel::onEvent)
 }
 
-private const val PREVIEW_TEXT = "דּוֹר הֹלֵךְ וְדוֹר בָּא וְהָאָרֶץ לְעוֹלָם עֹמָדֶת"
+private const val PREVIEW_TEXT = "הֲבֵ֤ל הֲבָלִים֙ אָמַ֣ר קֹהֶ֔לֶת הֲבֵ֥ל הֲבָלִ֖ים הַכֹּ֥ל הָֽבֶל׃"
 
 @Composable
 private fun FontsSettingsView(


### PR DESCRIPTION
## Summary
- Change font preview text to use Qohelet 1:2 with full taamim (cantillation marks)
- Previous text only had nikudot (vowel points), not taamim

Fixes #278