### PR TITLE
fix(installer): display error messages in English or Hebrew instead of French

### DIFF
--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -15,6 +15,7 @@ windows = { version = "0.58", features = [
     "Win32_System_LibraryLoader",
     "Win32_System_Threading",
     "Win32_Security",
+    "Win32_Globalization",
 ] }
 
 # Image decoding


### PR DESCRIPTION
## Summary
- Detect system UI language using Windows API (`GetUserDefaultUILanguage`)
- Display error messages in English by default
- Display error messages in Hebrew (with RTL support) when system is configured for Hebrew
- Remove French messages

## Changes
- `installer/src/main.rs`: Added `is_hebrew_system()` function and updated `launch_application()` error messages
- `installer/Cargo.toml`: Added `Win32_Globalization` feature

Fixes #323