### PR TITLE
fix(compose): improve BookContentView stability

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/BookContentPanel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/BookContentPanel.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.paging.compose.collectAsLazyPagingItems
 import io.github.kdroidfilter.seforimapp.core.presentation.components.HorizontalDivider
 import io.github.kdroidfilter.seforimapp.features.bookcontent.BookContentEvent
 import io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookContentState
@@ -128,6 +129,9 @@ private fun BookContentPanelContent(
             }
         }
 
+    // Collect paging data here to keep BookContentView skippable
+    val lazyPagingItems = providers.linesPagingData.collectAsLazyPagingItems()
+
     Column(modifier = Modifier.fillMaxSize()) {
         EnhancedVerticalSplitPane(
             splitPaneState = uiState.layout.contentSplitState.asStable(),
@@ -138,7 +142,7 @@ private fun BookContentPanelContent(
                     firstContent = {
                         BookContentView(
                             bookId = selectedBook.id,
-                            linesPagingData = providers.linesPagingData,
+                            lazyPagingItems = lazyPagingItems,
                             selectedLineIds = uiState.content.selectedLineIds,
                             primarySelectedLineId = uiState.content.primarySelectedLineId,
                             onLineSelect = { line, isModifier ->

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BookContentView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BookContentView.kt
@@ -44,9 +44,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import androidx.paging.LoadState
-import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
-import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import io.github.kdroidfilter.seforim.htmlparser.buildAnnotatedFromHtml
 import io.github.kdroidfilter.seforimapp.core.presentation.components.CountBadge
@@ -71,10 +69,14 @@ import org.jetbrains.jewel.ui.component.CircularProgressIndicator
 import org.jetbrains.jewel.ui.component.Text
 
 @OptIn(FlowPreview::class)
+@Suppress(
+    "ComposeUnstableCollections",
+    "ParamsComparedByRef",
+) // LazyPagingItems is inherently mutable; recomposition on paging changes is expected
 @Composable
 fun BookContentView(
     bookId: Long,
-    linesPagingData: Flow<PagingData<Line>>,
+    lazyPagingItems: LazyPagingItems<Line>,
     selectedLineIds: Set<Long>,
     primarySelectedLineId: Long?,
     onLineSelect: (Line, Boolean) -> Unit,
@@ -96,9 +98,6 @@ fun BookContentView(
     onPrefetchLineConnections: (List<Long>) -> Unit = {},
     isSelected: Boolean = true,
 ) {
-    // Collect paging data
-    val lazyPagingItems: LazyPagingItems<Line> = linesPagingData.collectAsLazyPagingItems()
-
     // Don't use the saved scroll position initially if we have an anchor
     // The restoration will be handled after pagination loads
     val listState =


### PR DESCRIPTION
## Summary
- Move `Flow<PagingData<Line>>` collection from `BookContentView` to parent `BookContentPanel`
- Pass `LazyPagingItems<Line>` directly to improve Compose compiler stability analysis
- Add suppress annotations for inherently mutable paging types

## Test plan
- [x] Verify app compiles without errors
- [x] Verify book content scrolling and paging work correctly
- [x] Verify no visual regressions in BookContentView