### PR TITLE
fix(jlink): add jdk.management module for Lucene HotSpot detection

### DIFF
--- a/SeforimApp/build.gradle.kts
+++ b/SeforimApp/build.gradle.kts
@@ -240,7 +240,15 @@ compose.desktop {
                     "-XX:MaxGCPauseMillis=50",
                 )
 
-            modules("java.sql", "jdk.unsupported", "jdk.security.auth", "jdk.accessibility", "jdk.incubator.vector")
+            modules(
+                "java.sql",
+                "java.management",
+                "jdk.management",
+                "jdk.unsupported",
+                "jdk.security.auth",
+                "jdk.accessibility",
+                "jdk.incubator.vector",
+            )
             targetFormats(TargetFormat.Pkg, TargetFormat.Msi, TargetFormat.Deb, TargetFormat.Rpm, TargetFormat.Dmg)
             vendor = "KDroidFilter"
 


### PR DESCRIPTION
## Summary
- Add `java.management` and `jdk.management` modules to the jlink runtime image
- Fixes Lucene warnings about missing HotSpot VM detection in distributable builds
- Enables Lucene Vector API (SIMD) optimizations and accurate RAM usage estimation

## Context
Lucene detects HotSpot by accessing `com.sun.management.HotSpotDiagnosticMXBean` via reflection. This class lives in the `jdk.management` module, which was not included in the jlink image. Without it, Lucene falls back to slower scalar operations and conservative memory estimation.

## Test plan
- [x] Run `./gradlew :SeforimApp:runDistributable` and verify Lucene HotSpot warnings are gone
- [x] Verify search functionality works correctly