### PR TITLE
feat: add compact mode for vertical sidebar bars

### DIFF
--- a/SeforimApp/src/commonMain/composeResources/values/strings.xml
+++ b/SeforimApp/src/commonMain/composeResources/values/strings.xml
@@ -299,6 +299,8 @@
     <string name="settings_show_zmanim_widgets_description">כאשר אפשרות זו מופעלת, יוצגו בדף הבית וידג'טים עם זמני היום ההלכתיים (נץ החמה, שקיעה, זמני תפילה וכו').</string>
     <string name="settings_use_opengl">השתמש ב-OpenGL במקום DirectX</string>
     <string name="settings_use_opengl_description">הפעל אפשרות זו רק אם אתה נתקל בבעיות תצוגה עם DirectX, כגון הבהובים או ריצודים במסך. שינוי זה יחול לאחר הפעלה מחדש של היישום.</string>
+    <string name="settings_compact_mode">מצב קומפקטי לסרגל הצדדי</string>
+    <string name="settings_compact_mode_description">כאשר אפשרות זו מופעלת, הסרגלים הצדדיים יוצגו בצורה צפופה יותר: האייקונים יהיו קטנים יותר והטקסט שמתחת לאייקונים לא יוצג.</string>
     <!-- Theme style selector -->
     <string name="settings_theme_style_label">סגנון ערכת נושא</string>
     <string name="settings_theme_style_classic">קלאסי</string>

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/SelectableActionButtonWithTooltip.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/SelectableActionButtonWithTooltip.kt
@@ -3,6 +3,8 @@ package io.github.kdroidfilter.seforimapp.core.presentation.components
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -11,6 +13,8 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.kdroidfilter.seforimapp.core.presentation.theme.ThemeUtils
+import io.github.kdroidfilter.seforimapp.core.settings.AppSettings
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.Icon
@@ -33,6 +37,15 @@ fun SelectableIconButtonWithToolip(
     enabled: Boolean = true,
     shortcutHint: String? = null,
 ) {
+    val compactMode by AppSettings.compactModeFlow.collectAsState()
+    val isIslands = ThemeUtils.isIslandsStyle()
+    val iconSize = if (compactMode) 22.dp else 24.dp
+    val buttonPadding = when {
+        compactMode -> 2.dp
+        isIslands -> 2.dp
+        else -> 4.dp
+    }
+
     Tooltip({
         if (shortcutHint.isNullOrBlank()) {
             Text(toolTipText)
@@ -49,7 +62,9 @@ fun SelectableIconButtonWithToolip(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .height(64.dp)
+                    .then(
+                        if (compactMode) Modifier.aspectRatio(1f) else Modifier.height(64.dp),
+                    )
                     .pointerHoverIcon(PointerIcon.Hand),
             focusable = false,
             enabled = enabled,
@@ -97,22 +112,24 @@ fun SelectableIconButtonWithToolip(
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center,
-                modifier = Modifier.padding(4.dp),
+                modifier = Modifier.padding(buttonPadding),
             ) {
                 Icon(
                     icon,
                     iconDescription,
-                    tint = if (enabled)JewelTheme.globalColors.text.selected else JewelTheme.globalColors.text.disabled,
-                    modifier = Modifier.size(24.dp),
+                    tint = if (enabled) JewelTheme.globalColors.text.selected else JewelTheme.globalColors.text.disabled,
+                    modifier = Modifier.size(iconSize),
                 )
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    label,
-                    color = if (enabled) JewelTheme.globalColors.text.normal else JewelTheme.globalColors.text.disabled,
-                    fontSize = 10.sp,
-                    textAlign = TextAlign.Center,
-                    lineHeight = 10.sp,
-                )
+                if (!compactMode) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        label,
+                        color = if (enabled) JewelTheme.globalColors.text.normal else JewelTheme.globalColors.text.disabled,
+                        fontSize = 10.sp,
+                        textAlign = TextAlign.Center,
+                        lineHeight = 10.sp,
+                    )
+                }
             }
         }
     }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/VerticalLateralBar.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/VerticalLateralBar.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -23,6 +25,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.kdroidfilter.seforimapp.core.presentation.theme.ThemeUtils
+import io.github.kdroidfilter.seforimapp.core.settings.AppSettings
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.Orientation
 import org.jetbrains.jewel.ui.component.Divider
@@ -49,6 +52,8 @@ fun VerticalLateralBar(
     val lazyColumnVerticalArrangement = Arrangement.spacedBy(4.dp)
 
     val isIslands = ThemeUtils.isIslandsStyle()
+    val compactMode by AppSettings.compactModeFlow.collectAsState()
+    val barWidth = if (compactMode) 48.dp else 64.dp
     val outerModifier =
         if (isIslands) {
             val horizontalPadding =
@@ -57,12 +62,12 @@ fun VerticalLateralBar(
                     VerticalLateralBarPosition.End -> PaddingValues(start = 4.dp, end = 6.dp)
                 }
             modifier
-                .width(64.dp)
+                .width(barWidth)
                 .fillMaxHeight()
                 .padding(vertical = 6.dp)
                 .padding(horizontalPadding)
         } else {
-            modifier.width(64.dp).fillMaxHeight()
+            modifier.width(barWidth).fillMaxHeight()
         }
     Row(modifier = outerModifier) {
         if (!isIslands && position == VerticalLateralBarPosition.End) {

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/settings/AppSettings.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/settings/AppSettings.kt
@@ -76,6 +76,9 @@ object AppSettings {
     // Rendering backend (Windows only)
     private const val KEY_USE_OPENGL = "use_opengl"
 
+    // Compact mode for vertical bars
+    private const val KEY_COMPACT_MODE = "compact_mode"
+
     // Backing Settings storage (can be replaced at startup if needed)
     @Volatile
     private var settings: Settings = Settings()
@@ -122,6 +125,10 @@ object AppSettings {
     // StateFlow for zmanim widgets visibility
     private val _showZmanimWidgetsFlow = MutableStateFlow(isShowZmanimWidgetsEnabled())
     val showZmanimWidgetsFlow: StateFlow<Boolean> = _showZmanimWidgetsFlow.asStateFlow()
+
+    // StateFlow for compact mode
+    private val _compactModeFlow = MutableStateFlow(isCompactModeEnabled())
+    val compactModeFlow: StateFlow<Boolean> = _compactModeFlow.asStateFlow()
 
     // Font preference flows
     private val _bookFontCodeFlow = MutableStateFlow(getBookFontCode())
@@ -308,6 +315,14 @@ object AppSettings {
         settings[KEY_USE_OPENGL] = enabled
     }
 
+    // Compact mode for vertical bars
+    fun isCompactModeEnabled(): Boolean = settings[KEY_COMPACT_MODE, false]
+
+    fun setCompactModeEnabled(enabled: Boolean) {
+        settings[KEY_COMPACT_MODE] = enabled
+        _compactModeFlow.value = enabled
+    }
+
     // Saved session blob (JSON)
     fun getSavedSessionJson(): String? {
         // Prefer chunked storage if present
@@ -460,6 +475,7 @@ object AppSettings {
         _databasePathFlow.value = null
         _persistSessionFlow.value = true
         _showZmanimWidgetsFlow.value = true
+        _compactModeFlow.value = false
         _bookFontCodeFlow.value = DEFAULT_BOOK_FONT
         _commentaryFontCodeFlow.value = DEFAULT_COMMENTARY_FONT
         _targumFontCodeFlow.value = DEFAULT_TARGUM_FONT

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/general/GeneralSettingsEvents.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/general/GeneralSettingsEvents.kt
@@ -17,5 +17,9 @@ sealed interface GeneralSettingsEvents {
         val value: Boolean,
     ) : GeneralSettingsEvents
 
+    data class SetCompactMode(
+        val value: Boolean,
+    ) : GeneralSettingsEvents
+
     data object ResetApp : GeneralSettingsEvents
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/general/GeneralSettingsState.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/general/GeneralSettingsState.kt
@@ -9,6 +9,7 @@ data class GeneralSettingsState(
     val persistSession: Boolean = true,
     val showZmanimWidgets: Boolean = true,
     val useOpenGl: Boolean = false,
+    val compactMode: Boolean = false,
     val resetDone: Boolean = false,
 ) {
     companion object {
@@ -19,6 +20,7 @@ data class GeneralSettingsState(
                 persistSession = true,
                 showZmanimWidgets = true,
                 useOpenGl = false,
+                compactMode = false,
                 resetDone = false,
             )
     }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/general/GeneralSettingsViewModel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/general/GeneralSettingsViewModel.kt
@@ -26,19 +26,22 @@ class GeneralSettingsViewModel : ViewModel() {
     private val persist = MutableStateFlow(AppSettings.isPersistSessionEnabled())
     private val showZmanim = MutableStateFlow(AppSettings.isShowZmanimWidgetsEnabled())
     private val useOpenGl = MutableStateFlow(AppSettings.isUseOpenGlEnabled())
+    private val compactMode = MutableStateFlow(AppSettings.isCompactModeEnabled())
     private val resetDone = MutableStateFlow(false)
 
     val state =
         combine(
             combine(dbPath, closeTree, persist) { path, c, p -> Triple(path, c, p) },
             combine(showZmanim, useOpenGl, resetDone) { z, gl, r -> Triple(z, gl, r) },
-        ) { (path, c, p), (z, gl, r) ->
+            compactMode,
+        ) { (path, c, p), (z, gl, r), compact ->
             GeneralSettingsState(
                 databasePath = path,
                 closeTreeOnNewBook = c,
                 persistSession = p,
                 showZmanimWidgets = z,
                 useOpenGl = gl,
+                compactMode = compact,
                 resetDone = r,
             )
         }.stateIn(
@@ -50,6 +53,7 @@ class GeneralSettingsViewModel : ViewModel() {
                 persistSession = persist.value,
                 showZmanimWidgets = showZmanim.value,
                 useOpenGl = useOpenGl.value,
+                compactMode = compactMode.value,
                 resetDone = resetDone.value,
             ),
         )
@@ -71,6 +75,10 @@ class GeneralSettingsViewModel : ViewModel() {
             is GeneralSettingsEvents.SetUseOpenGl -> {
                 AppSettings.setUseOpenGlEnabled(event.value)
                 useOpenGl.value = event.value
+            }
+            is GeneralSettingsEvents.SetCompactMode -> {
+                AppSettings.setCompactModeEnabled(event.value)
+                compactMode.value = event.value
             }
             is GeneralSettingsEvents.ResetApp -> {
                 // Get the databases directory

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/GeneralSettingsScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/GeneralSettingsScreen.kt
@@ -57,6 +57,8 @@ import seforimapp.seforimapp.generated.resources.AppIcon
 import seforimapp.seforimapp.generated.resources.Res
 import seforimapp.seforimapp.generated.resources.close_book_tree_on_new_book
 import seforimapp.seforimapp.generated.resources.close_book_tree_on_new_book_description
+import seforimapp.seforimapp.generated.resources.settings_compact_mode
+import seforimapp.seforimapp.generated.resources.settings_compact_mode_description
 import seforimapp.seforimapp.generated.resources.settings_info_app_version
 import seforimapp.seforimapp.generated.resources.settings_info_created_by
 import seforimapp.seforimapp.generated.resources.settings_info_license
@@ -140,6 +142,13 @@ private fun GeneralSettingsView(
                 description = Res.string.settings_show_zmanim_widgets_description,
                 checked = state.showZmanimWidgets,
                 onCheckedChange = { onEvent(GeneralSettingsEvents.SetShowZmanimWidgets(it)) },
+            )
+
+            SettingCard(
+                title = Res.string.settings_compact_mode,
+                description = Res.string.settings_compact_mode_description,
+                checked = state.compactMode,
+                onCheckedChange = { onEvent(GeneralSettingsEvents.SetCompactMode(it)) },
             )
 
             // OpenGL setting - Windows only


### PR DESCRIPTION
## Summary

- Add a **compact mode** setting for the lateral vertical bars, configurable from General Settings
- In compact mode: icons shrink to 22dp, text labels are hidden, buttons become square (`aspectRatio(1f)`), and bar width reduces to 48dp
- In Islands + non-compact mode: reduce internal button padding from 4dp to 2dp for a tighter look
- Setting is reactive via `StateFlow` — applies instantly without restart
- Hebrew strings added for the new setting card

## Test plan

- [x] Enable compact mode in Settings → General and verify sidebar icons are smaller with no labels
- [x] Verify buttons are square in compact mode (height = width)
- [x] Disable compact mode and verify normal mode is restored (64dp height, labels visible)
- [x] Switch to Islands theme in non-compact mode and verify reduced internal padding
- [x] Verify setting persists across app restarts
- [x] Test on both Start and End vertical bars (BookContent and Search screens)