### PR TITLE
fix: position vertical bar tooltips beside buttons, title bar below

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/SelectableActionButtonWithTooltip.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/SelectableActionButtonWithTooltip.kt
@@ -1,18 +1,27 @@
 package io.github.kdroidfilter.seforimapp.core.presentation.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.TooltipPlacement
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.PopupPositionProvider
 import io.github.kdroidfilter.seforimapp.core.presentation.theme.ThemeUtils
 import io.github.kdroidfilter.seforimapp.core.settings.AppSettings
 import org.jetbrains.jewel.foundation.theme.JewelTheme
@@ -23,6 +32,7 @@ import org.jetbrains.jewel.ui.component.Tooltip
 import org.jetbrains.jewel.ui.component.styling.IconButtonColors
 import org.jetbrains.jewel.ui.component.styling.IconButtonStyle
 import org.jetbrains.jewel.ui.theme.iconButtonStyle
+import org.jetbrains.jewel.ui.theme.tooltipStyle
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -46,17 +56,91 @@ fun SelectableIconButtonWithToolip(
         else -> 4.dp
     }
 
-    Tooltip({
-        if (shortcutHint.isNullOrBlank()) {
-            Text(toolTipText)
+    val barPosition = LocalVerticalBarPosition.current
+    val density = LocalDensity.current
+    val sideTooltipPlacement: TooltipPlacement? =
+        if (barPosition == null) {
+            null
         } else {
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
-                Text(toolTipText)
-
-                Text(shortcutHint, color = JewelTheme.globalColors.text.disabled)
+            remember(barPosition, density) {
+                val gap = with(density) { 4.dp.roundToPx() }
+                object : TooltipPlacement {
+                    @Composable
+                    override fun positionProvider(cursorPosition: Offset): PopupPositionProvider =
+                        object : PopupPositionProvider {
+                            override fun calculatePosition(
+                                anchorBounds: IntRect,
+                                windowSize: IntSize,
+                                layoutDirection: LayoutDirection,
+                                popupContentSize: IntSize,
+                            ): IntOffset {
+                                val y =
+                                    (anchorBounds.top + (anchorBounds.height - popupContentSize.height) / 2)
+                                        .coerceIn(
+                                            0,
+                                            (windowSize.height - popupContentSize.height).coerceAtLeast(0),
+                                        )
+                                // In RTL, Start is physically on the right and End on the left.
+                                val isPhysicallyOnRight =
+                                    (barPosition == VerticalLateralBarPosition.Start && layoutDirection == LayoutDirection.Rtl) ||
+                                        (barPosition == VerticalLateralBarPosition.End && layoutDirection == LayoutDirection.Ltr)
+                                val x =
+                                    if (isPhysicallyOnRight) {
+                                        anchorBounds.left - popupContentSize.width - gap
+                                    } else {
+                                        anchorBounds.right + gap
+                                    }
+                                return IntOffset(x, y)
+                            }
+                        }
+                }
             }
         }
-    }) {
+
+    val baseStyle = JewelTheme.iconButtonStyle
+    val buttonStyle =
+        remember(isSelected, baseStyle) {
+            val c = baseStyle.colors
+            IconButtonStyle(
+                colors =
+                    IconButtonColors(
+                        foregroundSelectedActivated = c.foregroundSelectedActivated,
+                        background = if (isSelected) c.backgroundSelected else c.background,
+                        backgroundDisabled = c.backgroundDisabled,
+                        backgroundSelected = c.backgroundSelected,
+                        backgroundSelectedActivated = c.backgroundSelectedActivated,
+                        backgroundFocused = c.backgroundFocused,
+                        backgroundPressed = c.backgroundPressed,
+                        backgroundHovered = if (isSelected) c.backgroundSelected else c.backgroundHovered,
+                        border = c.border,
+                        borderDisabled = c.borderDisabled,
+                        borderSelected = c.borderSelected,
+                        borderSelectedActivated = c.borderSelectedActivated,
+                        borderFocused = c.borderFocused,
+                        borderPressed = c.borderPressed,
+                        borderHovered = if (isSelected) c.borderSelected else c.borderHovered,
+                    ),
+                metrics = baseStyle.metrics,
+            )
+        }
+
+    Tooltip(
+        modifier = modifier,
+        tooltip = {
+            if (shortcutHint.isNullOrBlank()) {
+                Text(toolTipText)
+            } else {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(toolTipText)
+                    Text(shortcutHint, color = JewelTheme.globalColors.text.disabled)
+                }
+            }
+        },
+        tooltipPlacement = sideTooltipPlacement ?: JewelTheme.tooltipStyle.metrics.placement,
+    ) {
         ActionButton(
             onClick = onClick,
             modifier =
@@ -68,46 +152,7 @@ fun SelectableIconButtonWithToolip(
                     .pointerHoverIcon(PointerIcon.Hand),
             focusable = false,
             enabled = enabled,
-            style =
-                IconButtonStyle(
-                    colors =
-                        IconButtonColors(
-                            foregroundSelectedActivated =
-                                JewelTheme.iconButtonStyle.colors.foregroundSelectedActivated,
-                            background =
-                                if (isSelected) {
-                                    JewelTheme.iconButtonStyle.colors.backgroundSelected
-                                } else {
-                                    JewelTheme.iconButtonStyle.colors.background
-                                },
-                            backgroundDisabled = JewelTheme.iconButtonStyle.colors.backgroundDisabled,
-                            backgroundSelected = JewelTheme.iconButtonStyle.colors.backgroundSelected,
-                            backgroundSelectedActivated =
-                                JewelTheme.iconButtonStyle.colors.backgroundSelectedActivated,
-                            backgroundFocused = JewelTheme.iconButtonStyle.colors.backgroundFocused,
-                            backgroundPressed = JewelTheme.iconButtonStyle.colors.backgroundPressed,
-                            backgroundHovered =
-                                if (isSelected) {
-                                    JewelTheme.iconButtonStyle.colors.backgroundSelected
-                                } else {
-                                    JewelTheme.iconButtonStyle.colors.backgroundHovered
-                                },
-                            border = JewelTheme.iconButtonStyle.colors.border,
-                            borderDisabled = JewelTheme.iconButtonStyle.colors.borderDisabled,
-                            borderSelected = JewelTheme.iconButtonStyle.colors.borderSelected,
-                            borderSelectedActivated =
-                                JewelTheme.iconButtonStyle.colors.borderSelectedActivated,
-                            borderFocused = JewelTheme.iconButtonStyle.colors.borderFocused,
-                            borderPressed = JewelTheme.iconButtonStyle.colors.borderPressed,
-                            borderHovered =
-                                if (isSelected) {
-                                    JewelTheme.iconButtonStyle.colors.borderSelected
-                                } else {
-                                    JewelTheme.iconButtonStyle.colors.borderHovered
-                                },
-                        ),
-                    metrics = JewelTheme.iconButtonStyle.metrics,
-                ),
+            style = buttonStyle,
         ) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/TitleBarActionButton.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/TitleBarActionButton.kt
@@ -1,6 +1,7 @@
 package io.github.kdroidfilter.seforimapp.core.presentation.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.TooltipPlacement
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -10,8 +11,14 @@ import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.PopupPositionProvider
 import io.github.kdroidfilter.seforimapp.core.presentation.theme.ThemeUtils
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.IconActionButton
@@ -79,16 +86,40 @@ fun TitleBarActionButton(
             Modifier.width(40.dp).fillMaxHeight()
         }
 
-    Tooltip({
-        if (shortcutHint.isNullOrBlank()) {
-            Text(tooltipText)
-        } else {
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text(tooltipText)
-                Text(shortcutHint, color = JewelTheme.globalColors.text.disabled)
+    val belowAnchorPlacement =
+        remember {
+            object : TooltipPlacement {
+                @Composable
+                override fun positionProvider(cursorPosition: Offset): PopupPositionProvider =
+                    object : PopupPositionProvider {
+                        override fun calculatePosition(
+                            anchorBounds: IntRect,
+                            windowSize: IntSize,
+                            layoutDirection: LayoutDirection,
+                            popupContentSize: IntSize,
+                        ): IntOffset =
+                            IntOffset(
+                                x = (anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2)
+                                    .coerceIn(0, (windowSize.width - popupContentSize.width).coerceAtLeast(0)),
+                                y = anchorBounds.bottom,
+                            )
+                    }
             }
         }
-    }) {
+
+    Tooltip(
+        tooltip = {
+            if (shortcutHint.isNullOrBlank()) {
+                Text(tooltipText)
+            } else {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(tooltipText)
+                    Text(shortcutHint, color = JewelTheme.globalColors.text.disabled)
+                }
+            }
+        },
+        tooltipPlacement = belowAnchorPlacement,
+    ) {
         IconActionButton(
             key = key,
             onClick = onClick,

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/VerticalLateralBar.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/VerticalLateralBar.kt
@@ -16,7 +16,9 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,6 +35,8 @@ enum class VerticalLateralBarPosition {
     Start,
     End,
 }
+
+val LocalVerticalBarPosition = compositionLocalOf<VerticalLateralBarPosition?> { null }
 
 @Composable
 fun VerticalLateralBar(
@@ -67,83 +71,85 @@ fun VerticalLateralBar(
         } else {
             modifier.width(barWidth).fillMaxHeight()
         }
-    Row(modifier = outerModifier) {
-        if (!isIslands && position == VerticalLateralBarPosition.End) {
-            Column {
-                VerticalDivider()
-            }
-        }
-        val innerModifier =
-            if (isIslands) {
-                Modifier
-                    .weight(1f)
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(JewelTheme.globalColors.panelBackground)
-            } else {
-                Modifier.weight(1f)
-            }
-        Column(modifier = innerModifier) {
-            Box(
-                modifier = boxModifier,
-                contentAlignment = Alignment.TopCenter,
-            ) {
-                LazyColumn(
-                    verticalArrangement = lazyColumnVerticalArrangement,
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    item {
-                        Spacer(Modifier.height(4.dp))
-                        if (topContentLabel != null) {
-                            Text(
-                                text = topContentLabel,
-                                fontSize = 14.sp,
-                                textDecoration = TextDecoration.Underline,
-                            )
-                            Spacer(Modifier.height(4.dp))
-                        }
-                        Column(
-                            verticalArrangement = Arrangement.spacedBy(4.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                        ) {
-                            topContent()
-                        }
-                        HorizontalDivider(
-                            modifier = Modifier.fillMaxWidth(0.5f).padding(top = 4.dp),
-                        )
-                    }
+    CompositionLocalProvider(LocalVerticalBarPosition provides position) {
+        Row(modifier = outerModifier) {
+            if (!isIslands && position == VerticalLateralBarPosition.End) {
+                Column {
+                    VerticalDivider()
                 }
             }
-            Box(
-                modifier = boxModifier,
-                contentAlignment = Alignment.TopCenter,
-            ) {
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.Bottom,
-                    horizontalAlignment = Alignment.CenterHorizontally,
+            val innerModifier =
+                if (isIslands) {
+                    Modifier
+                        .weight(1f)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(JewelTheme.globalColors.panelBackground)
+                } else {
+                    Modifier.weight(1f)
+                }
+            Column(modifier = innerModifier) {
+                Box(
+                    modifier = boxModifier,
+                    contentAlignment = Alignment.TopCenter,
                 ) {
-                    item {
-                        if (bottomContentLabel != null) {
-                            Text(
-                                text = bottomContentLabel,
-                                fontSize = 14.sp,
-                                textDecoration = TextDecoration.Underline,
-                            )
+                    LazyColumn(
+                        verticalArrangement = lazyColumnVerticalArrangement,
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        item {
                             Spacer(Modifier.height(4.dp))
-                        }
-                        Column(
-                            verticalArrangement = Arrangement.spacedBy(4.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                        ) {
-                            bottomContent()
+                            if (topContentLabel != null) {
+                                Text(
+                                    text = topContentLabel,
+                                    fontSize = 14.sp,
+                                    textDecoration = TextDecoration.Underline,
+                                )
+                                Spacer(Modifier.height(4.dp))
+                            }
+                            Column(
+                                verticalArrangement = Arrangement.spacedBy(4.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                            ) {
+                                topContent()
+                            }
+                            HorizontalDivider(
+                                modifier = Modifier.fillMaxWidth(0.5f).padding(top = 4.dp),
+                            )
                         }
                     }
                 }
+                Box(
+                    modifier = boxModifier,
+                    contentAlignment = Alignment.TopCenter,
+                ) {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalArrangement = Arrangement.Bottom,
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        item {
+                            if (bottomContentLabel != null) {
+                                Text(
+                                    text = bottomContentLabel,
+                                    fontSize = 14.sp,
+                                    textDecoration = TextDecoration.Underline,
+                                )
+                                Spacer(Modifier.height(4.dp))
+                            }
+                            Column(
+                                verticalArrangement = Arrangement.spacedBy(4.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                            ) {
+                                bottomContent()
+                            }
+                        }
+                    }
+                }
             }
-        }
-        if (!isIslands && position == VerticalLateralBarPosition.Start) {
-            Column {
-                VerticalDivider()
+            if (!isIslands && position == VerticalLateralBarPosition.Start) {
+                Column {
+                    VerticalDivider()
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add `LocalVerticalBarPosition` CompositionLocal to `VerticalLateralBar` so child button components automatically know which side they're on without requiring extra parameters at every call site
- Implement RTL-aware side `TooltipPlacement` in `SelectableIconButtonWithTooltip`: tooltip appears to the right of Start-bar buttons and to the left of End-bar buttons (inverted in RTL)
- Add below-anchor centered `TooltipPlacement` to `TitleBarActionButton`, matching the Chrome-style tab tooltip positioning
- Wrap `IconButtonStyle` construction in `remember(isSelected, baseStyle)` to avoid rebuilding 15-field data classes on every recomposition
- Simplify `TooltipPlacement`: compute pixel gap once inside the outer `remember` block instead of using a redundant nested `remember` inside `positionProvider`
- Apply `modifier` parameter to `Tooltip` root (fixes unused-parameter warning)

Fixes #363

## Test plan

- [x] Vertical bar tooltips appear to the **right** of Start-bar (left sidebar) buttons
- [x] Vertical bar tooltips appear to the **left** of End-bar (right sidebar) buttons
- [x] RTL layout: directions are correctly inverted
- [x] Title bar action button tooltips appear **below** the button, centered
- [x] Tooltips still appear correctly after switching theme (Islands / Classic)
- [x] Tooltips still appear correctly after switching dark/light mode