### PR TITLE
Fix tab selection glitch after drag-and-drop in Islands mode

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/TitleBarActionsButtonsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/components/TitleBarActionsButtonsView.kt
@@ -30,9 +30,8 @@ fun TitleBarActionsButtonsView() {
 
     // Access app graph outside of callbacks to avoid reading CompositionLocals in non-composable contexts
     val tabsViewModel: TabsViewModel = appGraph.tabsViewModel
-    val tabs = tabsViewModel.tabs.collectAsState().value
-    val selectedTabIndex = tabsViewModel.selectedTabIndex.collectAsState().value
-    val currentTab = tabs.getOrNull(selectedTabIndex)
+    val tabsState = tabsViewModel.state.collectAsState().value
+    val currentTab = tabsState.tabs.getOrNull(tabsState.selectedTabIndex)
     val findEnabled =
         when (val dest = currentTab?.destination) {
             is TabsDestination.Search -> true

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsContent.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsContent.kt
@@ -64,8 +64,9 @@ fun TabsContent() {
     val searchHomeViewModel = appGraph.searchHomeViewModel
     val persistedStore = appGraph.tabPersistedStateStore
 
-    val tabs by tabsViewModel.tabs.collectAsState()
-    val selectedTabIndex by tabsViewModel.selectedTabIndex.collectAsState()
+    val tabsState by tabsViewModel.state.collectAsState()
+    val tabs = tabsState.tabs
+    val selectedTabIndex = tabsState.selectedTabIndex
     val isRestoringSession by SessionManager.isRestoringSession.collectAsState()
 
     val searchUi by remember(searchHomeViewModel) { searchHomeViewModel.uiState }.collectAsState()
@@ -74,7 +75,7 @@ fun TabsContent() {
     // Helper to get current tab ID
     val currentTabId by remember {
         derivedStateOf {
-            tabs.getOrNull(selectedTabIndex)?.destination?.tabId
+            tabsState.tabs.getOrNull(tabsState.selectedTabIndex)?.destination?.tabId
         }
     }
 

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsView.kt
@@ -565,6 +565,10 @@ private fun RtlAwareTab(
     }
 
     var closeButtonState by remember(isActive) { mutableStateOf(ButtonState.of(active = isActive)) }
+    val dragAlpha by animateFloatAsState(
+        targetValue = if (isDragging) 0.7f else 1f,
+        animationSpec = tween(durationMillis = 150),
+    )
     val isIslands = ThemeUtils.isIslandsStyle()
     val lineColor by tabStyle.colors.underlineFor(tabState)
     val lineThickness = tabStyle.metrics.underlineThickness
@@ -627,7 +631,7 @@ private fun RtlAwareTab(
                             m
                         }
                     }.background(backgroundColor)
-                    .alpha(if (isDragging) 0.7f else 1f) // Visual feedback when dragging
+                    .alpha(dragAlpha)
                     .onGloballyPositioned { coords ->
                         val pos = coords.positionInWindow()
                         anchorOffset = IntOffset(pos.x.roundToInt(), pos.y.roundToInt())

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/main.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/main.kt
@@ -303,8 +303,9 @@ fun main() {
 
                         // Build dynamic window title: "AppName - CurrentTab"
                         val tabsVm = appGraph.tabsViewModel
-                        val tabs by tabsVm.tabs.collectAsState()
-                        val selectedIndex by tabsVm.selectedTabIndex.collectAsState()
+                        val tabsState by tabsVm.state.collectAsState()
+                        val tabs = tabsState.tabs
+                        val selectedIndex = tabsState.selectedTabIndex
                         val appTitle = stringResource(Res.string.app_name)
                         val selectedTab = tabs.getOrNull(selectedIndex)
                         val rawTitle = selectedTab?.title.orEmpty()

--- a/SeforimApp/src/jvmTest/kotlin/io/github/kdroidfilter/seforimapp/integration/TabsViewModelIntegrationTest.kt
+++ b/SeforimApp/src/jvmTest/kotlin/io/github/kdroidfilter/seforimapp/integration/TabsViewModelIntegrationTest.kt
@@ -44,16 +44,16 @@ class TabsViewModelIntegrationTest {
     @Test
     fun `viewModel initializes with one tab`() =
         runTest {
-            val tabs = viewModel.tabs.value
+            val tabs = viewModel.state.value.tabs
 
             assertEquals(1, tabs.size)
-            assertEquals(0, viewModel.selectedTabIndex.value)
+            assertEquals(0, viewModel.state.value.selectedTabIndex)
         }
 
     @Test
     fun `initial tab has correct structure`() =
         runTest {
-            val tab = viewModel.tabs.value.first()
+            val tab = viewModel.state.value.tabs.first()
 
             assertEquals(1, tab.id)
             assertTrue(tab.destination is TabsDestination.BookContent)
@@ -64,12 +64,12 @@ class TabsViewModelIntegrationTest {
     @Test
     fun `OnAdd event creates new tab at beginning`() =
         runTest {
-            val initialCount = viewModel.tabs.value.size
+            val initialCount = viewModel.state.value.tabs.size
 
             viewModel.onEvent(TabsEvents.OnAdd)
 
-            assertEquals(initialCount + 1, viewModel.tabs.value.size)
-            assertEquals(0, viewModel.selectedTabIndex.value) // New tab is selected
+            assertEquals(initialCount + 1, viewModel.state.value.tabs.size)
+            assertEquals(0, viewModel.state.value.selectedTabIndex) // New tab is selected
         }
 
     @Test
@@ -81,7 +81,7 @@ class TabsViewModelIntegrationTest {
 
             viewModel.openTab(destination)
 
-            val tabs = viewModel.tabs.value
+            val tabs = viewModel.state.value.tabs
             assertEquals(2, tabs.size)
             val newTab = tabs.first() // New tab is at the beginning
             assertTrue(newTab.destination is TabsDestination.BookContent)
@@ -97,7 +97,7 @@ class TabsViewModelIntegrationTest {
 
             viewModel.openTab(destination)
 
-            val tabs = viewModel.tabs.value
+            val tabs = viewModel.state.value.tabs
             val newTab = tabs.first()
             assertTrue(newTab.destination is TabsDestination.Search)
             assertEquals(searchQuery, (newTab.destination as TabsDestination.Search).searchQuery)
@@ -111,7 +111,7 @@ class TabsViewModelIntegrationTest {
 
             viewModel.openTab(destination)
 
-            val tabs = viewModel.tabs.value
+            val tabs = viewModel.state.value.tabs
             val newTab = tabs.first()
             assertTrue(newTab.destination is TabsDestination.Home)
         }
@@ -123,7 +123,7 @@ class TabsViewModelIntegrationTest {
                 viewModel.onEvent(TabsEvents.OnAdd)
             }
 
-            assertEquals(6, viewModel.tabs.value.size) // 1 initial + 5 added
+            assertEquals(6, viewModel.state.value.tabs.size) // 1 initial + 5 added
         }
 
     // ==================== Tab Selection Tests ====================
@@ -137,27 +137,27 @@ class TabsViewModelIntegrationTest {
 
             viewModel.onEvent(TabsEvents.OnSelect(2))
 
-            assertEquals(2, viewModel.selectedTabIndex.value)
+            assertEquals(2, viewModel.state.value.selectedTabIndex)
         }
 
     @Test
     fun `OnSelect with invalid index does nothing`() =
         runTest {
-            val initialIndex = viewModel.selectedTabIndex.value
+            val initialIndex = viewModel.state.value.selectedTabIndex
 
             viewModel.onEvent(TabsEvents.OnSelect(999))
 
-            assertEquals(initialIndex, viewModel.selectedTabIndex.value)
+            assertEquals(initialIndex, viewModel.state.value.selectedTabIndex)
         }
 
     @Test
     fun `OnSelect with negative index does nothing`() =
         runTest {
-            val initialIndex = viewModel.selectedTabIndex.value
+            val initialIndex = viewModel.state.value.selectedTabIndex
 
             viewModel.onEvent(TabsEvents.OnSelect(-1))
 
-            assertEquals(initialIndex, viewModel.selectedTabIndex.value)
+            assertEquals(initialIndex, viewModel.state.value.selectedTabIndex)
         }
 
     // ==================== Tab Closure Tests ====================
@@ -168,7 +168,7 @@ class TabsViewModelIntegrationTest {
             // Add tabs
             viewModel.onEvent(TabsEvents.OnAdd)
             viewModel.onEvent(TabsEvents.OnAdd)
-            assertEquals(3, viewModel.tabs.value.size)
+            assertEquals(3, viewModel.state.value.tabs.size)
 
             // Select middle tab
             viewModel.onEvent(TabsEvents.OnSelect(1))
@@ -176,25 +176,25 @@ class TabsViewModelIntegrationTest {
             // Close the selected tab
             viewModel.onEvent(TabsEvents.OnClose(1))
 
-            assertEquals(2, viewModel.tabs.value.size)
+            assertEquals(2, viewModel.state.value.tabs.size)
         }
 
     @Test
     fun `closing last remaining tab replaces it with fresh tab`() =
         runTest {
             val originalTabId =
-                viewModel.tabs.value
+                viewModel.state.value.tabs
                     .first()
                     .destination.tabId
 
             viewModel.onEvent(TabsEvents.OnClose(0))
 
             // Should still have one tab
-            assertEquals(1, viewModel.tabs.value.size)
+            assertEquals(1, viewModel.state.value.tabs.size)
             // But with a different tabId
             assertNotEquals(
                 originalTabId,
-                viewModel.tabs.value
+                viewModel.state.value.tabs
                     .first()
                     .destination.tabId,
             )
@@ -207,12 +207,12 @@ class TabsViewModelIntegrationTest {
             viewModel.onEvent(TabsEvents.OnAdd)
             viewModel.onEvent(TabsEvents.OnAdd)
             viewModel.onEvent(TabsEvents.OnAdd)
-            assertEquals(4, viewModel.tabs.value.size)
+            assertEquals(4, viewModel.state.value.tabs.size)
 
             viewModel.onEvent(TabsEvents.CloseAll)
 
-            assertEquals(1, viewModel.tabs.value.size)
-            assertEquals(0, viewModel.selectedTabIndex.value)
+            assertEquals(1, viewModel.state.value.tabs.size)
+            assertEquals(0, viewModel.state.value.selectedTabIndex)
         }
 
     @Test
@@ -222,15 +222,15 @@ class TabsViewModelIntegrationTest {
             viewModel.onEvent(TabsEvents.OnAdd)
             viewModel.onEvent(TabsEvents.OnAdd)
             viewModel.onEvent(TabsEvents.OnAdd)
-            assertEquals(4, viewModel.tabs.value.size)
+            assertEquals(4, viewModel.state.value.tabs.size)
 
-            val targetTab = viewModel.tabs.value[2]
+            val targetTab = viewModel.state.value.tabs[2]
             viewModel.onEvent(TabsEvents.CloseOthers(2))
 
-            assertEquals(1, viewModel.tabs.value.size)
+            assertEquals(1, viewModel.state.value.tabs.size)
             assertEquals(
                 targetTab.id,
-                viewModel.tabs.value
+                viewModel.state.value.tabs
                     .first()
                     .id,
             )
@@ -243,11 +243,11 @@ class TabsViewModelIntegrationTest {
             viewModel.onEvent(TabsEvents.OnAdd)
             viewModel.onEvent(TabsEvents.OnAdd)
             viewModel.onEvent(TabsEvents.OnAdd)
-            assertEquals(4, viewModel.tabs.value.size)
+            assertEquals(4, viewModel.state.value.tabs.size)
 
             viewModel.onEvent(TabsEvents.CloseLeft(2))
 
-            assertEquals(2, viewModel.tabs.value.size)
+            assertEquals(2, viewModel.state.value.tabs.size)
         }
 
     @Test
@@ -257,11 +257,11 @@ class TabsViewModelIntegrationTest {
             viewModel.onEvent(TabsEvents.OnAdd)
             viewModel.onEvent(TabsEvents.OnAdd)
             viewModel.onEvent(TabsEvents.OnAdd)
-            assertEquals(4, viewModel.tabs.value.size)
+            assertEquals(4, viewModel.state.value.tabs.size)
 
             viewModel.onEvent(TabsEvents.CloseRight(1))
 
-            assertEquals(2, viewModel.tabs.value.size)
+            assertEquals(2, viewModel.state.value.tabs.size)
         }
 
     // ==================== Tab Reordering Tests ====================
@@ -274,14 +274,14 @@ class TabsViewModelIntegrationTest {
             viewModel.onEvent(TabsEvents.OnAdd)
             viewModel.onEvent(TabsEvents.OnAdd)
 
-            val originalFirstTabId = viewModel.tabs.value[0].id
-            val originalLastTabId = viewModel.tabs.value[3].id
+            val originalFirstTabId = viewModel.state.value.tabs[0].id
+            val originalLastTabId = viewModel.state.value.tabs[3].id
 
             // Move first tab to last position
             viewModel.onEvent(TabsEvents.OnReorder(0, 3))
 
-            assertEquals(originalFirstTabId, viewModel.tabs.value[3].id)
-            assertNotEquals(originalFirstTabId, viewModel.tabs.value[0].id)
+            assertEquals(originalFirstTabId, viewModel.state.value.tabs[3].id)
+            assertNotEquals(originalFirstTabId, viewModel.state.value.tabs[0].id)
         }
 
     @Test
@@ -290,22 +290,22 @@ class TabsViewModelIntegrationTest {
             viewModel.onEvent(TabsEvents.OnAdd)
             viewModel.onEvent(TabsEvents.OnAdd)
 
-            val tabsBefore = viewModel.tabs.value.map { it.id }
+            val tabsBefore = viewModel.state.value.tabs.map { it.id }
 
             viewModel.onEvent(TabsEvents.OnReorder(1, 1))
 
-            val tabsAfter = viewModel.tabs.value.map { it.id }
+            val tabsAfter = viewModel.state.value.tabs.map { it.id }
             assertEquals(tabsBefore, tabsAfter)
         }
 
     @Test
     fun `OnReorder with invalid indices does nothing`() =
         runTest {
-            val tabsBefore = viewModel.tabs.value.toList()
+            val tabsBefore = viewModel.state.value.tabs.toList()
 
             viewModel.onEvent(TabsEvents.OnReorder(-1, 999))
 
-            assertEquals(tabsBefore, viewModel.tabs.value)
+            assertEquals(tabsBefore, viewModel.state.value.tabs)
         }
 
     // ==================== Replace Tab Tests ====================
@@ -314,14 +314,14 @@ class TabsViewModelIntegrationTest {
     fun `replaceCurrentTabDestination preserves tabId`() =
         runTest {
             val originalTabId =
-                viewModel.tabs.value
+                viewModel.state.value.tabs
                     .first()
                     .destination.tabId
             val newDestination = TabsDestination.Search(searchQuery = "test", tabId = "ignored")
 
             viewModel.replaceCurrentTabDestination(newDestination)
 
-            val updatedTab = viewModel.tabs.value.first()
+            val updatedTab = viewModel.state.value.tabs.first()
             assertEquals(originalTabId, updatedTab.destination.tabId)
             assertTrue(updatedTab.destination is TabsDestination.Search)
         }
@@ -330,14 +330,14 @@ class TabsViewModelIntegrationTest {
     fun `replaceCurrentTabWithNewTabId creates new tabId`() =
         runTest {
             val originalTabId =
-                viewModel.tabs.value
+                viewModel.state.value.tabs
                     .first()
                     .destination.tabId
             val newDestination = TabsDestination.BookContent(bookId = 100, tabId = "ignored")
 
             viewModel.replaceCurrentTabWithNewTabId(newDestination)
 
-            val updatedTab = viewModel.tabs.value.first()
+            val updatedTab = viewModel.state.value.tabs.first()
             assertNotEquals(originalTabId, updatedTab.destination.tabId)
         }
 
@@ -355,18 +355,18 @@ class TabsViewModelIntegrationTest {
 
             viewModel.restoreTabs(destinations, selectedIndex = 1)
 
-            assertEquals(3, viewModel.tabs.value.size)
-            assertEquals(1, viewModel.selectedTabIndex.value)
+            assertEquals(3, viewModel.state.value.tabs.size)
+            assertEquals(1, viewModel.state.value.selectedTabIndex)
         }
 
     @Test
     fun `restoreTabs with empty list does nothing`() =
         runTest {
-            val tabsBefore = viewModel.tabs.value.toList()
+            val tabsBefore = viewModel.state.value.tabs.toList()
 
             viewModel.restoreTabs(emptyList(), selectedIndex = 0)
 
-            assertEquals(tabsBefore, viewModel.tabs.value)
+            assertEquals(tabsBefore, viewModel.state.value.tabs)
         }
 
     @Test
@@ -380,7 +380,7 @@ class TabsViewModelIntegrationTest {
 
             viewModel.restoreTabs(destinations, selectedIndex = 999)
 
-            assertEquals(1, viewModel.selectedTabIndex.value) // Clamped to last valid index
+            assertEquals(1, viewModel.state.value.selectedTabIndex) // Clamped to last valid index
         }
 
     // ==================== Title Update Tests ====================
@@ -389,7 +389,7 @@ class TabsViewModelIntegrationTest {
     fun `title update manager updates tab title`() =
         runTest {
             val tabId =
-                viewModel.tabs.value
+                viewModel.state.value.tabs
                     .first()
                     .destination.tabId
             val newTitle = "Updated Title"
@@ -399,7 +399,7 @@ class TabsViewModelIntegrationTest {
             // Allow the coroutine to process
             kotlinx.coroutines.delay(100)
 
-            val tab = viewModel.tabs.value.first()
+            val tab = viewModel.state.value.tabs.first()
             assertEquals(newTitle, tab.title)
             assertEquals(TabType.BOOK, tab.tabType)
         }
@@ -417,7 +417,7 @@ class TabsViewModelIntegrationTest {
 
             viewModel.openTab(destination)
 
-            val tab = viewModel.tabs.value.first()
+            val tab = viewModel.state.value.tabs.first()
             assertEquals(TabType.BOOK, tab.tabType)
         }
 
@@ -432,7 +432,7 @@ class TabsViewModelIntegrationTest {
 
             viewModel.openTab(destination)
 
-            val tab = viewModel.tabs.value.first()
+            val tab = viewModel.state.value.tabs.first()
             assertEquals(TabType.SEARCH, tab.tabType)
         }
 
@@ -447,7 +447,7 @@ class TabsViewModelIntegrationTest {
 
             viewModel.openTab(destination)
 
-            val tab = viewModel.tabs.value.first()
+            val tab = viewModel.state.value.tabs.first()
             assertEquals(TabType.SEARCH, tab.tabType)
         }
 
@@ -461,7 +461,7 @@ class TabsViewModelIntegrationTest {
 
             viewModel.openTab(destination)
 
-            val tab = viewModel.tabs.value.first()
+            val tab = viewModel.state.value.tabs.first()
             assertEquals(TabType.SEARCH, tab.tabType)
         }
 
@@ -476,13 +476,13 @@ class TabsViewModelIntegrationTest {
 
             // Select last tab (index 2)
             viewModel.onEvent(TabsEvents.OnSelect(2))
-            assertEquals(2, viewModel.selectedTabIndex.value)
+            assertEquals(2, viewModel.state.value.selectedTabIndex)
 
             // Close first tab (index 0)
             viewModel.onEvent(TabsEvents.OnClose(0))
 
             // Selected index should decrease by 1
-            assertEquals(1, viewModel.selectedTabIndex.value)
+            assertEquals(1, viewModel.state.value.selectedTabIndex)
         }
 
     @Test
@@ -494,13 +494,13 @@ class TabsViewModelIntegrationTest {
 
             // Select first tab (index 0)
             viewModel.onEvent(TabsEvents.OnSelect(0))
-            assertEquals(0, viewModel.selectedTabIndex.value)
+            assertEquals(0, viewModel.state.value.selectedTabIndex)
 
             // Close last tab (index 2)
             viewModel.onEvent(TabsEvents.OnClose(2))
 
             // Selected index should remain 0
-            assertEquals(0, viewModel.selectedTabIndex.value)
+            assertEquals(0, viewModel.state.value.selectedTabIndex)
         }
 
     @Test
@@ -513,7 +513,7 @@ class TabsViewModelIntegrationTest {
             viewModel.onEvent(TabsEvents.OnAdd)
             viewModel.onEvent(TabsEvents.OnAdd)
 
-            val tabIds = viewModel.tabs.value.map { it.id }
+            val tabIds = viewModel.state.value.tabs.map { it.id }
             assertEquals(tabIds.size, tabIds.toSet().size) // All IDs should be unique
         }
 }

--- a/navigation/src/commonMain/kotlin/io/github/kdroidfilter/seforim/tabs/TabsState.kt
+++ b/navigation/src/commonMain/kotlin/io/github/kdroidfilter/seforim/tabs/TabsState.kt
@@ -12,7 +12,4 @@ data class TabsState(
 
 @Composable
 fun rememberTabsState(viewModel: TabsViewModel): TabsState =
-    TabsState(
-        tabs = viewModel.tabs.collectAsState().value,
-        selectedTabIndex = viewModel.selectedTabIndex.collectAsState().value,
-    )
+    viewModel.state.collectAsState().value

--- a/navigation/src/commonMain/kotlin/io/github/kdroidfilter/seforim/tabs/TabsViewModel.kt
+++ b/navigation/src/commonMain/kotlin/io/github/kdroidfilter/seforim/tabs/TabsViewModel.kt
@@ -6,7 +6,13 @@ import androidx.compose.runtime.Stable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.util.*
 import kotlin.math.max
@@ -24,24 +30,34 @@ class TabsViewModel(
     private val titleUpdateManager: TabTitleUpdateManager,
     startDestination: TabsDestination,
 ) : ViewModel() {
-    private var _nextTabId = 2 // Commence à 2 car on a déjà un onglet par défaut
-    private val _tabs =
-        MutableStateFlow(
-            listOf(
+    private var _nextTabId = 2
+
+    private val _state = MutableStateFlow(
+        TabsState(
+            tabs = listOf(
                 TabItem(
                     id = 1,
                     title = getTabTitle(startDestination),
                     destination = startDestination,
                 ),
             ),
-        )
-    val tabs = _tabs.asStateFlow()
+            selectedTabIndex = 0,
+        ),
+    )
+    val state: StateFlow<TabsState> = _state.asStateFlow()
 
-    private val _selectedTabIndex = MutableStateFlow(0)
-    val selectedTabIndex = _selectedTabIndex.asStateFlow()
+    // Backward-compatible derived flows for consumers that only need one field
+    val tabs: StateFlow<List<TabItem>> = _state
+        .map { it.tabs }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, _state.value.tabs)
+
+    val selectedTabIndex: StateFlow<Int> = _state
+        .map { it.selectedTabIndex }
+        .distinctUntilChanged()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, _state.value.selectedTabIndex)
 
     init {
-        // Écouter les mises à jour de titre
         viewModelScope.launch {
             titleUpdateManager.titleUpdates.collect { update ->
                 updateTabTitle(update.tabId, update.newTitle, update.tabType)
@@ -63,327 +79,250 @@ class TabsViewModel(
     }
 
     private fun closeTab(index: Int) {
-        val currentTabs = _tabs.value
+        val currentState = _state.value
+        val currentTabs = currentState.tabs
 
-        if (index < 0 || index >= currentTabs.size) return // Index invalide
+        if (index < 0 || index >= currentTabs.size) return
 
-        // If it's the last remaining tab, reset it to a fresh one instead of removing it
         if (currentTabs.size == 1) {
-            // Replace the current (and only) tab with a brand‑new tabId and default destination
-            // This clears the previous tab state and avoids leaving the UI without any tab
             replaceCurrentTabWithNewTabId(
                 TabsDestination.BookContent(bookId = -1, tabId = UUID.randomUUID().toString()),
             )
-            _selectedTabIndex.value = 0
+            _state.update { it.copy(selectedTabIndex = 0) }
             return
         }
 
-        // Capture tabId to clear any per-tab cached state
-
-        // Supprimer l'onglet à l'index donné
         val newTabs = currentTabs.toMutableList().apply { removeAt(index) }
-        _tabs.value = newTabs.toList()
-
-        // Ajuster l'index sélectionné
-        val currentSelectedIndex = _selectedTabIndex.value
-        val newSelectedIndex =
-            when {
-                // Si on ferme l'onglet sélectionné
-                index == currentSelectedIndex -> {
-                    // Si on ferme le dernier onglet, sélectionner le précédent
-                    if (index == newTabs.size) {
-                        max(0, index - 1)
-                    } else {
-                        // Sinon, garder le même index (qui pointera vers l'onglet suivant)
-                        index.coerceIn(0, newTabs.lastIndex)
-                    }
+        val currentSelectedIndex = currentState.selectedTabIndex
+        val newSelectedIndex = when {
+            index == currentSelectedIndex -> {
+                if (index == newTabs.size) {
+                    max(0, index - 1)
+                } else {
+                    index.coerceIn(0, newTabs.lastIndex)
                 }
-                // Si on ferme un onglet avant celui sélectionné
-                index < currentSelectedIndex -> currentSelectedIndex - 1
-                // Si on ferme un onglet après celui sélectionné
-                else -> currentSelectedIndex
             }
+            index < currentSelectedIndex -> currentSelectedIndex - 1
+            else -> currentSelectedIndex
+        }
 
-        _selectedTabIndex.value = newSelectedIndex
+        _state.value = TabsState(tabs = newTabs.toList(), selectedTabIndex = newSelectedIndex)
     }
 
     private fun selectTab(index: Int) {
-        val currentTabs = _tabs.value
-        if (index in 0..currentTabs.lastIndex && index != _selectedTabIndex.value) {
-            _selectedTabIndex.value = index
+        _state.update { current ->
+            if (index in 0..current.tabs.lastIndex && index != current.selectedTabIndex) {
+                current.copy(selectedTabIndex = index)
+            } else {
+                current
+            }
         }
     }
 
-    private fun reorderTabs(
-        fromIndex: Int,
-        toIndex: Int,
-    ) {
-        val currentTabs = _tabs.value
-        if (fromIndex !in 0..currentTabs.lastIndex || toIndex !in 0..currentTabs.lastIndex) return
-        if (fromIndex == toIndex) return
+    private fun reorderTabs(fromIndex: Int, toIndex: Int) {
+        _state.update { current ->
+            val currentTabs = current.tabs
+            if (fromIndex !in 0..currentTabs.lastIndex || toIndex !in 0..currentTabs.lastIndex) return@update current
+            if (fromIndex == toIndex) return@update current
 
-        val newTabs = currentTabs.toMutableList()
-        val movedTab = newTabs.removeAt(fromIndex)
-        newTabs.add(toIndex, movedTab)
-        _tabs.value = newTabs.toList()
+            val newTabs = currentTabs.toMutableList()
+            val movedTab = newTabs.removeAt(fromIndex)
+            newTabs.add(toIndex, movedTab)
 
-        // Adjust selected index: track which tab was selected by its identity
-        val selectedTab = currentTabs.getOrNull(_selectedTabIndex.value)
-        if (selectedTab != null) {
-            val newSelectedIndex = newTabs.indexOfFirst { it.id == selectedTab.id }
-            if (newSelectedIndex != -1) {
-                _selectedTabIndex.value = newSelectedIndex
+            val selectedTab = currentTabs.getOrNull(current.selectedTabIndex)
+            val newSelectedIndex = if (selectedTab != null) {
+                newTabs.indexOfFirst { it.id == selectedTab.id }.takeIf { it != -1 } ?: current.selectedTabIndex
+            } else {
+                current.selectedTabIndex
             }
+
+            TabsState(tabs = newTabs.toList(), selectedTabIndex = newSelectedIndex)
         }
     }
 
     private fun addTab() {
         val destination = TabsDestination.BookContent(bookId = -1, tabId = UUID.randomUUID().toString())
-        val newTab =
-            TabItem(
-                id = _nextTabId++,
-                title = getTabTitle(destination),
-                destination = destination,
-                tabType = tabTypeFor(destination),
-            )
-        _tabs.value = listOf(newTab) + _tabs.value
-        _selectedTabIndex.value = 0
-        // Trigger GC when a new tab is opened via the plus button
+        val newTab = TabItem(
+            id = _nextTabId++,
+            title = getTabTitle(destination),
+            destination = destination,
+            tabType = tabTypeFor(destination),
+        )
+        _state.update { current ->
+            TabsState(tabs = listOf(newTab) + current.tabs, selectedTabIndex = 0)
+        }
         System.gc()
     }
 
     private fun addTabWithDestination(destination: TabsDestination) {
-        // Preserve the provided tabId to allow callers to pre-initialize tab state.
-        val newDestination =
-            when (destination) {
-                is TabsDestination.Home -> TabsDestination.Home(destination.tabId, destination.version)
-                is TabsDestination.Search -> TabsDestination.Search(destination.searchQuery, destination.tabId)
-                is TabsDestination.BookContent -> TabsDestination.BookContent(destination.bookId, destination.tabId, destination.lineId)
-            }
+        val newDestination = when (destination) {
+            is TabsDestination.Home -> TabsDestination.Home(destination.tabId, destination.version)
+            is TabsDestination.Search -> TabsDestination.Search(destination.searchQuery, destination.tabId)
+            is TabsDestination.BookContent -> TabsDestination.BookContent(destination.bookId, destination.tabId, destination.lineId)
+        }
 
-        val newTab =
-            TabItem(
-                id = _nextTabId++,
-                title = getTabTitle(newDestination),
-                destination = newDestination,
-                tabType = tabTypeFor(newDestination),
-            )
-        _tabs.value = listOf(newTab) + _tabs.value
-        _selectedTabIndex.value = 0
+        val newTab = TabItem(
+            id = _nextTabId++,
+            title = getTabTitle(newDestination),
+            destination = newDestination,
+            tabType = tabTypeFor(newDestination),
+        )
+        _state.update { current ->
+            TabsState(tabs = listOf(newTab) + current.tabs, selectedTabIndex = 0)
+        }
     }
 
     private fun closeAllTabs() {
-        val currentTabs = _tabs.value
-
-        // Create a fresh default tab
         val destination = TabsDestination.BookContent(bookId = -1, tabId = UUID.randomUUID().toString())
-        val newTab =
-            TabItem(
-                id = _nextTabId++,
-                title = getTabTitle(destination),
-                destination = destination,
-                tabType = TabType.SEARCH,
-            )
-        _tabs.value = listOf(newTab)
-        _selectedTabIndex.value = 0
+        val newTab = TabItem(
+            id = _nextTabId++,
+            title = getTabTitle(destination),
+            destination = destination,
+            tabType = TabType.SEARCH,
+        )
+        _state.value = TabsState(tabs = listOf(newTab), selectedTabIndex = 0)
         System.gc()
     }
 
     private fun closeOthers(index: Int) {
-        val currentTabs = _tabs.value
-        if (index !in 0..currentTabs.lastIndex) return
-
-        val keep = currentTabs[index]
-        _tabs.value = listOf(keep)
-        _selectedTabIndex.value = 0
+        _state.update { current ->
+            if (index !in 0..current.tabs.lastIndex) return@update current
+            TabsState(tabs = listOf(current.tabs[index]), selectedTabIndex = 0)
+        }
         System.gc()
     }
 
     private fun closeLeft(index: Int) {
-        val currentTabs = _tabs.value
-        if (index !in 0..currentTabs.lastIndex) return
-
-        val newTabs = currentTabs.drop(index).toList()
-        _tabs.value = newTabs
-
-        // Adjust selection: preserve selection if still present; otherwise select the first (which is the original index tab)
-        val s = _selectedTabIndex.value
-        _selectedTabIndex.value =
-            if (s >= index) {
-                (s - index).coerceIn(0, newTabs.lastIndex)
+        _state.update { current ->
+            if (index !in 0..current.tabs.lastIndex) return@update current
+            val newTabs = current.tabs.drop(index)
+            val newSelected = if (current.selectedTabIndex >= index) {
+                (current.selectedTabIndex - index).coerceIn(0, newTabs.lastIndex)
             } else {
                 0
             }
+            TabsState(tabs = newTabs, selectedTabIndex = newSelected)
+        }
         System.gc()
     }
 
     private fun closeRight(index: Int) {
-        val currentTabs = _tabs.value
-        if (index !in 0..currentTabs.lastIndex) return
-
-        val newTabs = currentTabs.take(index + 1).toList()
-        _tabs.value = newTabs
-
-        // Adjust selection: if the previous selected was to the right, clamp to last (which is index)
-        val s = _selectedTabIndex.value
-        _selectedTabIndex.value = if (s <= index) s else newTabs.lastIndex
+        _state.update { current ->
+            if (index !in 0..current.tabs.lastIndex) return@update current
+            val newTabs = current.tabs.take(index + 1)
+            val newSelected = if (current.selectedTabIndex <= index) current.selectedTabIndex else newTabs.lastIndex
+            TabsState(tabs = newTabs, selectedTabIndex = newSelected)
+        }
         System.gc()
     }
 
-    /**
-     * Public API to open a new tab with the given destination.
-     * Keeps the provided tabId, selects the new tab.
-     */
     fun openTab(destination: TabsDestination) {
         addTabWithDestination(destination)
     }
 
-    /**
-     * Replaces the destination of the currently selected tab, preserving the tabId.
-     * Does not create a new tab. Updates the tab title accordingly.
-     */
     fun replaceCurrentTabDestination(destination: TabsDestination) {
-        val index = _selectedTabIndex.value
-        val currentTabs = _tabs.value
-        if (index !in 0..currentTabs.lastIndex) return
+        _state.update { current ->
+            val index = current.selectedTabIndex
+            if (index !in 0..current.tabs.lastIndex) return@update current
 
-        val current = currentTabs[index]
-        val newDestination =
-            when (destination) {
-                is TabsDestination.Home ->
-                    TabsDestination.Home(
-                        tabId = current.destination.tabId,
-                        version = System.currentTimeMillis(),
-                    )
-                is TabsDestination.Search ->
-                    TabsDestination.Search(
-                        searchQuery = destination.searchQuery,
-                        tabId = current.destination.tabId,
-                    )
-                is TabsDestination.BookContent ->
-                    TabsDestination.BookContent(
-                        bookId = destination.bookId,
-                        tabId = current.destination.tabId,
-                        lineId = destination.lineId,
-                    )
-            }
-
-        val updated =
-            current.copy(
-                title = getTabTitle(newDestination),
-                destination = newDestination,
-                tabType = tabTypeFor(newDestination),
-            )
-        _tabs.value = currentTabs.toMutableList().apply { set(index, updated) }.toList()
-    }
-
-    /**
-     * Replaces the currently selected tab with a fresh tabId, similar to opening
-     * a brand-new tab but keeping the same visual slot. Clears the previous tabId
-     * state to avoid leaking state into the new content.
-     */
-    fun replaceCurrentTabWithNewTabId(destination: TabsDestination) {
-        val index = _selectedTabIndex.value
-        val currentTabs = _tabs.value
-        if (index !in 0..currentTabs.lastIndex) return
-
-        val current = currentTabs[index]
-        val newTabId = UUID.randomUUID().toString()
-
-        val newDestination =
-            when (destination) {
-                is TabsDestination.Home ->
-                    TabsDestination.Home(
-                        tabId = newTabId,
-                        version = System.currentTimeMillis(),
-                    )
-                is TabsDestination.Search ->
-                    TabsDestination.Search(
-                        searchQuery = destination.searchQuery,
-                        tabId = newTabId,
-                    )
-                is TabsDestination.BookContent ->
-                    TabsDestination.BookContent(
-                        bookId = destination.bookId,
-                        tabId = newTabId,
-                        lineId = destination.lineId,
-                    )
-            }
-
-        val updated =
-            current.copy(
-                title = getTabTitle(newDestination),
-                destination = newDestination,
-                tabType = tabTypeFor(newDestination),
-            )
-        _tabs.value = currentTabs.toMutableList().apply { set(index, updated) }.toList()
-    }
-
-    /**
-     * Replaces the entire tab list with the provided destinations.
-     * Used for cold-boot session restore to avoid keeping the default tab alive.
-     */
-    fun restoreTabs(
-        destinations: List<TabsDestination>,
-        selectedIndex: Int,
-    ) {
-        if (destinations.isEmpty()) return
-
-        val restoredTabs =
-            destinations.mapIndexed { index, destination ->
-                TabItem(
-                    id = index + 1,
-                    title = getTabTitle(destination),
-                    destination = destination,
-                    tabType = tabTypeFor(destination),
+            val tab = current.tabs[index]
+            val newDestination = when (destination) {
+                is TabsDestination.Home -> TabsDestination.Home(
+                    tabId = tab.destination.tabId,
+                    version = System.currentTimeMillis(),
+                )
+                is TabsDestination.Search -> TabsDestination.Search(
+                    searchQuery = destination.searchQuery,
+                    tabId = tab.destination.tabId,
+                )
+                is TabsDestination.BookContent -> TabsDestination.BookContent(
+                    bookId = destination.bookId,
+                    tabId = tab.destination.tabId,
+                    lineId = destination.lineId,
                 )
             }
 
-        _tabs.value = restoredTabs
-        _selectedTabIndex.value = selectedIndex.coerceIn(0, restoredTabs.lastIndex)
+            val updated = tab.copy(
+                title = getTabTitle(newDestination),
+                destination = newDestination,
+                tabType = tabTypeFor(newDestination),
+            )
+            current.copy(tabs = current.tabs.toMutableList().apply { set(index, updated) }.toList())
+        }
+    }
+
+    fun replaceCurrentTabWithNewTabId(destination: TabsDestination) {
+        _state.update { current ->
+            val index = current.selectedTabIndex
+            if (index !in 0..current.tabs.lastIndex) return@update current
+
+            val newTabId = UUID.randomUUID().toString()
+            val newDestination = when (destination) {
+                is TabsDestination.Home -> TabsDestination.Home(
+                    tabId = newTabId,
+                    version = System.currentTimeMillis(),
+                )
+                is TabsDestination.Search -> TabsDestination.Search(
+                    searchQuery = destination.searchQuery,
+                    tabId = newTabId,
+                )
+                is TabsDestination.BookContent -> TabsDestination.BookContent(
+                    bookId = destination.bookId,
+                    tabId = newTabId,
+                    lineId = destination.lineId,
+                )
+            }
+
+            val updated = current.tabs[index].copy(
+                title = getTabTitle(newDestination),
+                destination = newDestination,
+                tabType = tabTypeFor(newDestination),
+            )
+            current.copy(tabs = current.tabs.toMutableList().apply { set(index, updated) }.toList())
+        }
+    }
+
+    fun restoreTabs(destinations: List<TabsDestination>, selectedIndex: Int) {
+        if (destinations.isEmpty()) return
+
+        val restoredTabs = destinations.mapIndexed { index, destination ->
+            TabItem(
+                id = index + 1,
+                title = getTabTitle(destination),
+                destination = destination,
+                tabType = tabTypeFor(destination),
+            )
+        }
+
+        _state.value = TabsState(
+            tabs = restoredTabs,
+            selectedTabIndex = selectedIndex.coerceIn(0, restoredTabs.lastIndex),
+        )
         _nextTabId = (restoredTabs.maxOfOrNull { it.id } ?: 0) + 1
     }
 
-    private fun tabTypeFor(destination: TabsDestination): TabType =
-        when (destination) {
-            is TabsDestination.Home -> TabType.SEARCH
-            is TabsDestination.Search -> TabType.SEARCH
-            is TabsDestination.BookContent -> if (destination.bookId > 0) TabType.BOOK else TabType.SEARCH
-        }
+    private fun tabTypeFor(destination: TabsDestination): TabType = when (destination) {
+        is TabsDestination.Home -> TabType.SEARCH
+        is TabsDestination.Search -> TabType.SEARCH
+        is TabsDestination.BookContent -> if (destination.bookId > 0) TabType.BOOK else TabType.SEARCH
+    }
 
-    private fun getTabTitle(destination: TabsDestination): String =
-        when (destination) {
-            // For Home, return empty so UI can localize via resources
-            is TabsDestination.Home -> ""
-            is TabsDestination.Search -> destination.searchQuery
-            is TabsDestination.BookContent -> if (destination.bookId > 0) "${destination.bookId}" else ""
-        }
+    private fun getTabTitle(destination: TabsDestination): String = when (destination) {
+        is TabsDestination.Home -> ""
+        is TabsDestination.Search -> destination.searchQuery
+        is TabsDestination.BookContent -> if (destination.bookId > 0) "${destination.bookId}" else ""
+    }
 
-    /**
-     * Updates the title of a tab with the given tabId.
-     *
-     * @param tabId The ID of the tab to update
-     * @param newTitle The new title for the tab
-     * @param tabType The type of content in the tab
-     */
-    private fun updateTabTitle(
-        tabId: String,
-        newTitle: String,
-        tabType: TabType = TabType.SEARCH,
-    ) {
-        val currentTabs = _tabs.value
-        val updatedTabs =
-            currentTabs.map { tab ->
+    private fun updateTabTitle(tabId: String, newTitle: String, tabType: TabType = TabType.SEARCH) {
+        _state.update { current ->
+            val updatedTabs = current.tabs.map { tab ->
                 if (tab.destination.tabId == tabId) {
                     tab.copy(title = newTitle, tabType = tabType)
                 } else {
                     tab
                 }
             }
-
-        // Only update if there was a change
-        if (updatedTabs != currentTabs) {
-            _tabs.value = updatedTabs
+            if (updatedTabs != current.tabs) current.copy(tabs = updatedTabs) else current
         }
     }
 }


### PR DESCRIPTION
## Summary
- Combines `_tabs` and `_selectedTabIndex` into a single `MutableStateFlow<TabsState>` for atomic updates, eliminating a visual glitch where the wrong tab appeared briefly selected after drag-and-drop reordering
- Adds smooth alpha animation (150ms) for drag feedback instead of an instant toggle
- Migrates all consumers (`main.kt`, `TabsContent`, `TitleBarActionsButtonsView`, tests) to use the combined `state` flow

## Test plan
- [x] All existing `TabsViewModelIntegrationTest` tests pass
- [x] Compiles successfully on master
- [x] Manual: drag-and-drop a tab in Islands mode — no selection flash
- [x] Manual: verify tab keyboard shortcuts (Ctrl+T/W/Tab) still work
- [x] Manual: verify context menu actions (close all/others/left/right)