### PR TITLE
Fix split pane gaps and invisible drag zones on hidden panels

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/BookContentStateManager.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/BookContentStateManager.kt
@@ -28,6 +28,12 @@ class BookContentStateManager(
     private fun loadInitialState(): BookContentState {
         val persisted: BookContentPersistedState = persistedStore.get(tabId)?.bookContent ?: BookContentPersistedState()
 
+        // Derive visibility flags so split pane positions match from the first frame
+        val navVisible = persisted.isBookTreeVisible
+        val tocVisible = persisted.isTocVisible
+        val bottomPaneVisible = persisted.showCommentaries || persisted.showSources
+        val targumVisible = persisted.showTargum
+
         return BookContentState(
             tabId = tabId,
             navigation =
@@ -38,7 +44,7 @@ class BookContentStateManager(
                     selectedCategory = null,
                     selectedBook = null,
                     searchText = persisted.navigationSearchText,
-                    isVisible = persisted.isBookTreeVisible,
+                    isVisible = navVisible,
                     scrollIndex = persisted.bookTreeScrollIndex,
                     scrollOffset = persisted.bookTreeScrollOffset,
                 ),
@@ -47,7 +53,7 @@ class BookContentStateManager(
                     expandedEntries = persisted.expandedTocEntryIds,
                     children = emptyMap(),
                     selectedEntryId = persisted.selectedTocEntryId.takeIf { it > 0 },
-                    isVisible = persisted.isTocVisible,
+                    isVisible = tocVisible,
                     scrollIndex = persisted.tocScrollIndex,
                     scrollOffset = persisted.tocScrollOffset,
                 ),
@@ -83,10 +89,26 @@ class BookContentStateManager(
                 ),
             layout =
                 LayoutState(
-                    mainSplitState = SplitPaneState(initialPositionPercentage = persisted.mainSplitPosition, moveEnabled = true),
-                    tocSplitState = SplitPaneState(initialPositionPercentage = persisted.tocSplitPosition, moveEnabled = true),
-                    contentSplitState = SplitPaneState(initialPositionPercentage = persisted.contentSplitPosition, moveEnabled = true),
-                    targumSplitState = SplitPaneState(initialPositionPercentage = persisted.targumSplitPosition, moveEnabled = true),
+                    mainSplitState =
+                        SplitPaneState(
+                            initialPositionPercentage = if (navVisible) persisted.mainSplitPosition else 0f,
+                            moveEnabled = navVisible,
+                        ),
+                    tocSplitState =
+                        SplitPaneState(
+                            initialPositionPercentage = if (tocVisible) persisted.tocSplitPosition else 0f,
+                            moveEnabled = tocVisible,
+                        ),
+                    contentSplitState =
+                        SplitPaneState(
+                            initialPositionPercentage = if (bottomPaneVisible) persisted.contentSplitPosition else 1f,
+                            moveEnabled = bottomPaneVisible,
+                        ),
+                    targumSplitState =
+                        SplitPaneState(
+                            initialPositionPercentage = if (targumVisible) persisted.targumSplitPosition else 1f,
+                            moveEnabled = targumVisible,
+                        ),
                     previousPositions =
                         PreviousPositions(
                             main = persisted.previousMainSplitPosition,

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/components/SplitPanes.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/components/SplitPanes.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -18,7 +17,6 @@ import org.jetbrains.compose.splitpane.VerticalSplitPane
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.Orientation
 import org.jetbrains.jewel.ui.component.Divider
-import kotlin.math.roundToInt
 
 @Stable
 @JvmInline
@@ -45,6 +43,7 @@ fun EnhancedHorizontalSplitPane(
     val isIslands = ThemeUtils.isIslandsStyle()
     val state = splitPaneState.value
     val effectiveSecondMin = if (secondContent == null) 0f else secondMinSize
+    val splitterVisible = showSplitter && secondContent != null
 
     // When the second pane is hidden, expand the first to 100% to avoid blank space
     LaunchedEffect(secondContent == null) {
@@ -60,17 +59,10 @@ fun EnhancedHorizontalSplitPane(
         }
     }
 
-    // Quantize splitter position to 2 decimal places to avoid layout jitter from
-    // floating-point noise, especially on small or non-integer pixel widths.
-    LaunchedEffect(state) {
-        snapshotFlow { state.positionPercentage }
-            .collect { rawPosition ->
-                val clamped = rawPosition.coerceIn(0f, 1f)
-                val quantized = (clamped * 100f).roundToInt() / 100f
-                if (quantized != rawPosition) {
-                    state.positionPercentage = quantized
-                }
-            }
+    // Disable drag when splitter is hidden so the library's default handle
+    // (8dp invisible drag zone) is never placed.
+    LaunchedEffect(splitterVisible) {
+        state.moveEnabled = splitterVisible
     }
 
     HorizontalSplitPane(
@@ -94,7 +86,7 @@ fun EnhancedHorizontalSplitPane(
                 Box(modifier = Modifier.fillMaxSize())
             }
         }
-        if (showSplitter && secondContent != null) {
+        if (splitterVisible) {
             splitter {
                 visiblePart {
                     if (!isIslands) {
@@ -134,6 +126,7 @@ fun EnhancedVerticalSplitPane(
     val isIslands = ThemeUtils.isIslandsStyle()
     val state = splitPaneState.value
     val effectiveSecondMin = if (secondContent == null) 0f else secondMinSize
+    val splitterVisible = showSplitter && secondContent != null
 
     // When the second pane is hidden, expand the first to 100% to avoid blank space
     LaunchedEffect(secondContent == null) {
@@ -149,17 +142,10 @@ fun EnhancedVerticalSplitPane(
         }
     }
 
-    // Quantize splitter position to 2 decimal places to avoid layout jitter from
-    // floating-point noise, especially on small or non-integer pixel widths.
-    LaunchedEffect(state) {
-        snapshotFlow { state.positionPercentage }
-            .collect { rawPosition ->
-                val clamped = rawPosition.coerceIn(0f, 1f)
-                val quantized = (clamped * 100f).roundToInt() / 100f
-                if (quantized != rawPosition) {
-                    state.positionPercentage = quantized
-                }
-            }
+    // Disable drag when splitter is hidden so the library's default handle
+    // (8dp invisible drag zone) is never placed.
+    LaunchedEffect(splitterVisible) {
+        state.moveEnabled = splitterVisible
     }
 
     VerticalSplitPane(
@@ -183,7 +169,7 @@ fun EnhancedVerticalSplitPane(
                 Box(modifier = Modifier.fillMaxSize())
             }
         }
-        if (showSplitter && secondContent != null) {
+        if (splitterVisible) {
             splitter {
                 visiblePart {
                     if (!isIslands) {

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/BookContentPanel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/BookContentPanel.kt
@@ -156,15 +156,24 @@ private fun BookContentPanelContent(
         }
 
     val isIslands = ThemeUtils.isIslandsStyle()
+    val hasBottomPane = uiState.content.showCommentaries || uiState.content.showSources
+    val panelBackground = JewelTheme.globalColors.panelBackground
+
     val paneCardModifier =
-        if (isIslands) {
-            Modifier
-                .fillMaxSize()
-                .padding(vertical = 6.dp, horizontal = 4.dp)
-                .clip(RoundedCornerShape(12.dp))
-                .background(JewelTheme.globalColors.panelBackground)
-        } else {
-            Modifier
+        remember(isIslands, panelBackground) {
+            islandsCardModifier(isIslands, panelBackground)
+        }
+    val topPaneCardModifier =
+        remember(isIslands, hasBottomPane, panelBackground) {
+            if (hasBottomPane) {
+                islandsCardModifier(isIslands, panelBackground, bottom = 3.dp)
+            } else {
+                islandsCardModifier(isIslands, panelBackground)
+            }
+        }
+    val bottomPaneCardModifier =
+        remember(isIslands, panelBackground) {
+            islandsCardModifier(isIslands, panelBackground, top = 3.dp)
         }
 
     // Collect paging data here to keep BookContentView skippable
@@ -189,7 +198,7 @@ private fun BookContentPanelContent(
                             onEvent = onEvent,
                             tabId = uiState.tabId,
                             showDiacritics = showDiacritics,
-                            modifier = paneCardModifier,
+                            modifier = topPaneCardModifier,
                             preservedListState = bookListState,
                             scrollIndex = uiState.content.scrollIndex,
                             scrollOffset = uiState.content.scrollOffset,
@@ -222,7 +231,7 @@ private fun BookContentPanelContent(
                                     onEvent = onEvent,
                                     lineConnections = connectionsCache,
                                     showDiacritics = showDiacritics,
-                                    modifier = paneCardModifier,
+                                    modifier = topPaneCardModifier,
                                 )
                             }
                         } else {
@@ -239,7 +248,7 @@ private fun BookContentPanelContent(
                                 onEvent = onEvent,
                                 lineConnections = connectionsCache,
                                 showDiacritics = showDiacritics,
-                                modifier = paneCardModifier,
+                                modifier = bottomPaneCardModifier,
                             )
                         }
                     }
@@ -251,7 +260,7 @@ private fun BookContentPanelContent(
                                 onEvent = onEvent,
                                 lineConnections = connectionsCache,
                                 showDiacritics = showDiacritics,
-                                modifier = paneCardModifier,
+                                modifier = bottomPaneCardModifier,
                             )
                         }
                     }
@@ -363,3 +372,19 @@ private fun BreadcrumbSection(
         )
     }
 }
+
+private fun islandsCardModifier(
+    isIslands: Boolean,
+    panelBackground: androidx.compose.ui.graphics.Color,
+    top: Dp = 6.dp,
+    bottom: Dp = 6.dp,
+): Modifier =
+    if (isIslands) {
+        Modifier
+            .fillMaxSize()
+            .padding(top = top, bottom = bottom, start = 4.dp, end = 4.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(panelBackground)
+    } else {
+        Modifier
+    }

--- a/SeforimApp/src/jvmTest/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/SplitPaneInitializationTest.kt
+++ b/SeforimApp/src/jvmTest/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/SplitPaneInitializationTest.kt
@@ -1,0 +1,337 @@
+@file:OptIn(ExperimentalSplitPaneApi::class)
+
+package io.github.kdroidfilter.seforimapp.features.bookcontent.state
+
+import io.github.kdroidfilter.seforimapp.framework.session.BookContentPersistedState
+import io.github.kdroidfilter.seforimapp.framework.session.TabPersistedStateStore
+import org.jetbrains.compose.splitpane.ExperimentalSplitPaneApi
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests that [BookContentStateManager] initializes [SplitPaneState] with correct
+ * position and moveEnabled values based on panel visibility flags.
+ *
+ * This prevents visible gaps on the first frame when hidden panels have non-collapsed
+ * split positions.
+ */
+class SplitPaneInitializationTest {
+    private lateinit var persistedStore: TabPersistedStateStore
+
+    private val testTabId = "test-tab-split"
+
+    @BeforeTest
+    fun setup() {
+        persistedStore = TabPersistedStateStore()
+    }
+
+    // ==================== Default (no persisted state) ====================
+
+    @Test
+    fun `new tab initializes mainSplitState with nav visible and default position`() {
+        // Given: No persisted state (new tab) — isBookTreeVisible defaults to true
+        val manager = BookContentStateManager(testTabId, persistedStore)
+        val layout = manager.state.value.layout
+
+        // Then: Nav is visible, position is the default, drag is enabled
+        assertEquals(SplitDefaults.MAIN, layout.mainSplitState.positionPercentage)
+        assertTrue(layout.mainSplitState.moveEnabled)
+    }
+
+    @Test
+    fun `new tab initializes tocSplitState collapsed because TOC is hidden by default`() {
+        // Given: No persisted state — isTocVisible defaults to false
+        val manager = BookContentStateManager(testTabId, persistedStore)
+        val layout = manager.state.value.layout
+
+        // Then: TOC is hidden, position is 0 (first pane collapsed), drag is disabled
+        assertEquals(0f, layout.tocSplitState.positionPercentage)
+        assertFalse(layout.tocSplitState.moveEnabled)
+    }
+
+    @Test
+    fun `new tab initializes contentSplitState expanded because commentaries are hidden by default`() {
+        // Given: No persisted state — showCommentaries and showSources default to false
+        val manager = BookContentStateManager(testTabId, persistedStore)
+        val layout = manager.state.value.layout
+
+        // Then: Bottom pane is hidden, position is 1 (first pane takes full space), drag is disabled
+        assertEquals(1f, layout.contentSplitState.positionPercentage)
+        assertFalse(layout.contentSplitState.moveEnabled)
+    }
+
+    @Test
+    fun `new tab initializes targumSplitState expanded because targum is hidden by default`() {
+        // Given: No persisted state — showTargum defaults to false
+        val manager = BookContentStateManager(testTabId, persistedStore)
+        val layout = manager.state.value.layout
+
+        // Then: Targum pane is hidden, position is 1, drag is disabled
+        assertEquals(1f, layout.targumSplitState.positionPercentage)
+        assertFalse(layout.targumSplitState.moveEnabled)
+    }
+
+    // ==================== Restored state with panels visible ====================
+
+    @Test
+    fun `restored state with TOC visible uses persisted position`() {
+        // Given: Persisted state with TOC visible
+        val savedPosition = 0.15f
+        persistedStore.update(testTabId) { current ->
+            current.copy(
+                bookContent =
+                    current.bookContent.copy(
+                        isTocVisible = true,
+                        tocSplitPosition = savedPosition,
+                    ),
+            )
+        }
+
+        // When: Creating state manager
+        val manager = BookContentStateManager(testTabId, persistedStore)
+        val layout = manager.state.value.layout
+
+        // Then: Uses saved position, drag enabled
+        assertEquals(savedPosition, layout.tocSplitState.positionPercentage)
+        assertTrue(layout.tocSplitState.moveEnabled)
+    }
+
+    @Test
+    fun `restored state with commentaries visible uses persisted position`() {
+        // Given: Persisted state with commentaries visible
+        val savedPosition = 0.65f
+        persistedStore.update(testTabId) { current ->
+            current.copy(
+                bookContent =
+                    current.bookContent.copy(
+                        showCommentaries = true,
+                        contentSplitPosition = savedPosition,
+                    ),
+            )
+        }
+
+        // When: Creating state manager
+        val manager = BookContentStateManager(testTabId, persistedStore)
+        val layout = manager.state.value.layout
+
+        // Then: Uses saved position, drag enabled
+        assertEquals(savedPosition, layout.contentSplitState.positionPercentage)
+        assertTrue(layout.contentSplitState.moveEnabled)
+    }
+
+    @Test
+    fun `restored state with sources visible uses persisted content position`() {
+        // Given: Sources visible (also uses contentSplitState)
+        val savedPosition = 0.8f
+        persistedStore.update(testTabId) { current ->
+            current.copy(
+                bookContent =
+                    current.bookContent.copy(
+                        showSources = true,
+                        contentSplitPosition = savedPosition,
+                    ),
+            )
+        }
+
+        // When: Creating state manager
+        val manager = BookContentStateManager(testTabId, persistedStore)
+        val layout = manager.state.value.layout
+
+        // Then: Content split is enabled because sources are visible
+        assertEquals(savedPosition, layout.contentSplitState.positionPercentage)
+        assertTrue(layout.contentSplitState.moveEnabled)
+    }
+
+    @Test
+    fun `restored state with targum visible uses persisted position`() {
+        // Given: Persisted state with targum visible
+        val savedPosition = 0.75f
+        persistedStore.update(testTabId) { current ->
+            current.copy(
+                bookContent =
+                    current.bookContent.copy(
+                        showTargum = true,
+                        targumSplitPosition = savedPosition,
+                    ),
+            )
+        }
+
+        // When: Creating state manager
+        val manager = BookContentStateManager(testTabId, persistedStore)
+        val layout = manager.state.value.layout
+
+        // Then: Uses saved position, drag enabled
+        assertEquals(savedPosition, layout.targumSplitState.positionPercentage)
+        assertTrue(layout.targumSplitState.moveEnabled)
+    }
+
+    // ==================== Restored state with panels hidden ====================
+
+    @Test
+    fun `restored state with nav hidden collapses main split to 0`() {
+        // Given: Nav hidden with a non-zero persisted position
+        persistedStore.update(testTabId) { current ->
+            current.copy(
+                bookContent =
+                    current.bookContent.copy(
+                        isBookTreeVisible = false,
+                        mainSplitPosition = 0.2f,
+                    ),
+            )
+        }
+
+        // When: Creating state manager
+        val manager = BookContentStateManager(testTabId, persistedStore)
+        val layout = manager.state.value.layout
+
+        // Then: Position is overridden to 0, drag disabled
+        assertEquals(0f, layout.mainSplitState.positionPercentage)
+        assertFalse(layout.mainSplitState.moveEnabled)
+    }
+
+    @Test
+    fun `restored state with TOC hidden collapses toc split to 0`() {
+        // Given: TOC hidden with a non-zero persisted position
+        persistedStore.update(testTabId) { current ->
+            current.copy(
+                bookContent =
+                    current.bookContent.copy(
+                        isTocVisible = false,
+                        tocSplitPosition = 0.15f,
+                    ),
+            )
+        }
+
+        // When: Creating state manager
+        val manager = BookContentStateManager(testTabId, persistedStore)
+        val layout = manager.state.value.layout
+
+        // Then: Position is overridden to 0, drag disabled
+        assertEquals(0f, layout.tocSplitState.positionPercentage)
+        assertFalse(layout.tocSplitState.moveEnabled)
+    }
+
+    @Test
+    fun `restored state with commentaries hidden expands content split to 1`() {
+        // Given: Both commentaries and sources hidden, but position was saved at 0.7
+        persistedStore.update(testTabId) { current ->
+            current.copy(
+                bookContent =
+                    current.bookContent.copy(
+                        showCommentaries = false,
+                        showSources = false,
+                        contentSplitPosition = 0.7f,
+                    ),
+            )
+        }
+
+        // When: Creating state manager
+        val manager = BookContentStateManager(testTabId, persistedStore)
+        val layout = manager.state.value.layout
+
+        // Then: Position is overridden to 1 (first pane takes all space), drag disabled
+        assertEquals(1f, layout.contentSplitState.positionPercentage)
+        assertFalse(layout.contentSplitState.moveEnabled)
+    }
+
+    @Test
+    fun `restored state with targum hidden expands targum split to 1`() {
+        // Given: Targum hidden, but position was saved at 0.8
+        persistedStore.update(testTabId) { current ->
+            current.copy(
+                bookContent =
+                    current.bookContent.copy(
+                        showTargum = false,
+                        targumSplitPosition = 0.8f,
+                    ),
+            )
+        }
+
+        // When: Creating state manager
+        val manager = BookContentStateManager(testTabId, persistedStore)
+        val layout = manager.state.value.layout
+
+        // Then: Position is overridden to 1, drag disabled
+        assertEquals(1f, layout.targumSplitState.positionPercentage)
+        assertFalse(layout.targumSplitState.moveEnabled)
+    }
+
+    // ==================== previousPositions are always preserved ====================
+
+    @Test
+    fun `previousPositions are restored regardless of visibility`() {
+        // Given: Hidden panels with saved previous positions
+        val prevMain = 0.12f
+        val prevToc = 0.08f
+        val prevContent = 0.65f
+        val prevSources = 0.9f
+        val prevTargum = 0.85f
+
+        persistedStore.update(testTabId) { current ->
+            current.copy(
+                bookContent =
+                    current.bookContent.copy(
+                        isBookTreeVisible = false,
+                        isTocVisible = false,
+                        showCommentaries = false,
+                        showTargum = false,
+                        previousMainSplitPosition = prevMain,
+                        previousTocSplitPosition = prevToc,
+                        previousContentSplitPosition = prevContent,
+                        previousSourcesSplitPosition = prevSources,
+                        previousTargumSplitPosition = prevTargum,
+                    ),
+            )
+        }
+
+        // When: Creating state manager
+        val manager = BookContentStateManager(testTabId, persistedStore)
+        val positions = manager.state.value.layout.previousPositions
+
+        // Then: Previous positions are always preserved (used to restore when toggling back)
+        assertEquals(prevMain, positions.main)
+        assertEquals(prevToc, positions.toc)
+        assertEquals(prevContent, positions.content)
+        assertEquals(prevSources, positions.sources)
+        assertEquals(prevTargum, positions.links)
+    }
+
+    // ==================== Save-restore round trip ====================
+
+    @Test
+    fun `save then restore preserves split positions for visible panels`() {
+        // Given: A manager with all panels visible and custom positions
+        persistedStore.update(testTabId) { current ->
+            current.copy(
+                bookContent =
+                    BookContentPersistedState(
+                        isBookTreeVisible = true,
+                        isTocVisible = true,
+                        showCommentaries = true,
+                        showTargum = true,
+                        mainSplitPosition = 0.1f,
+                        tocSplitPosition = 0.12f,
+                        contentSplitPosition = 0.6f,
+                        targumSplitPosition = 0.75f,
+                    ),
+            )
+        }
+        val manager = BookContentStateManager(testTabId, persistedStore)
+
+        // When: Adjusting positions and saving
+        manager.state.value.layout.mainSplitState.positionPercentage = 0.15f
+        manager.state.value.layout.tocSplitState.positionPercentage = 0.18f
+        manager.saveAllStates()
+
+        // Then: New manager loads the adjusted positions
+        val restored = BookContentStateManager(testTabId, persistedStore)
+        val layout = restored.state.value.layout
+        assertEquals(0.15f, layout.mainSplitState.positionPercentage)
+        assertEquals(0.18f, layout.tocSplitState.positionPercentage)
+        assertTrue(layout.mainSplitState.moveEnabled)
+        assertTrue(layout.tocSplitState.moveEnabled)
+    }
+}


### PR DESCRIPTION
## Summary

- Initialize `SplitPaneState` with correct `positionPercentage` and `moveEnabled` based on panel visibility flags at creation time, preventing first-frame layout gaps when panels start hidden (e.g. TOC at 5% instead of 0%, commentaries at 70% instead of 100%)
- Set `moveEnabled = false` when splitter is hidden so the library's default 8dp invisible drag handle is never placed — no more ghost resize cursors at hidden panel edges
- Remove the `snapshotFlow` quantization loop that ran continuously on every position change (unnecessary overhead)
- Fix doubled vertical padding between content and commentaries panes (was 12dp, now 6dp) by using asymmetric padding on adjacent panes
- Add 15 tests in `SplitPaneInitializationTest` covering all initialization scenarios

## Test plan

- [x] Open a book with commentaries — verify dividers still work normally (drag to resize, cursor appears only on divider)
- [x] Toggle category tree off (Ctrl+B) — verify no resize cursor at left edge, dragging does nothing
- [x] Toggle TOC off (Ctrl+Shift+B) — same verification
- [x] Toggle commentaries off (Ctrl+K) — verify no resize cursor at bottom edge
- [x] Close the last tab — new tab should have no visible gaps between panes
- [x] Toggle panels on/off rapidly — no ghost splitters or stuck states
- [x] Verify spacing between content and commentaries panes is consistent with horizontal gaps
- [x] Run `./gradlew :SeforimApp:jvmTest` — all tests pass