### PR TITLE
Fix: wrap CatalogRow buttons with FlowRow instead of hiding them

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/components/CatalogRow.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/components/CatalogRow.kt
@@ -2,8 +2,8 @@ package io.github.kdroidfilter.seforimapp.features.bookcontent.ui.panels.bookcon
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -19,11 +19,11 @@ import io.github.kdroidfilter.seforimapp.core.presentation.components.CatalogDro
 import io.github.kdroidfilter.seforimapp.core.presentation.theme.ThemeUtils
 import io.github.kdroidfilter.seforimapp.features.bookcontent.BookContentEvent
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun CatalogRow(
     onEvent: (BookContentEvent) -> Unit,
     modifier: Modifier = Modifier,
-    buttonWidth: Dp = 130.dp,
     spacing: Dp = 8.dp,
 ) {
     val outerPadding = if (ThemeUtils.isIslandsStyle()) 12.dp else 6.dp
@@ -35,89 +35,55 @@ fun CatalogRow(
                 .padding(outerPadding),
         contentAlignment = Alignment.TopStart,
     ) {
-        BoxWithConstraints(Modifier.fillMaxWidth()) {
-            val totalButtons = 7
-            // Compute how many catalog buttons we can show fully without overflow.
-            val maxVisible =
-                run {
-                    var count = totalButtons
-                    while (count > 1) {
-                        val required = buttonWidth * count + spacing * (count - 1)
-                        if (required <= maxWidth) break
-                        count--
-                    }
-                    count
-                }
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(spacing, Alignment.CenterHorizontally),
+            verticalArrangement = Arrangement.spacedBy(spacing),
+        ) {
+            val buttonModifier = Modifier.widthIn(max = 130.dp)
 
-            var rendered = 0
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(spacing, Alignment.CenterHorizontally),
-            ) {
-                if (rendered < maxVisible) {
-                    CatalogDropdown(
-                        spec = PrecomputedCatalog.Dropdowns.TANAKH,
-                        onEvent = onEvent,
-                        modifier = Modifier.widthIn(max = buttonWidth),
-                        popupWidthMultiplier = 1.50f,
-                    )
-                    rendered++
-                }
-                if (rendered < maxVisible) {
-                    CatalogDropdown(
-                        spec = PrecomputedCatalog.Dropdowns.MISHNA,
-                        onEvent = onEvent,
-                        modifier = Modifier.widthIn(max = buttonWidth),
-                    )
-                    rendered++
-                }
-                if (rendered < maxVisible) {
-                    CatalogDropdown(
-                        spec = PrecomputedCatalog.Dropdowns.BAVLI,
-                        onEvent = onEvent,
-                        modifier = Modifier.widthIn(max = buttonWidth),
-                        popupWidthMultiplier = 1.1f,
-                    )
-                    rendered++
-                }
-                if (rendered < maxVisible) {
-                    CatalogDropdown(
-                        spec = PrecomputedCatalog.Dropdowns.YERUSHALMI,
-                        onEvent = onEvent,
-                        modifier = Modifier.widthIn(max = buttonWidth),
-                        popupWidthMultiplier = 1.1f,
-                    )
-                    rendered++
-                }
-                if (rendered < maxVisible) {
-                    CatalogDropdown(
-                        spec = PrecomputedCatalog.Dropdowns.MISHNE_TORAH,
-                        onEvent = onEvent,
-                        modifier = Modifier.widthIn(max = buttonWidth),
-                        popupWidthMultiplier = 1.5f,
-                    )
-                    rendered++
-                }
-                if (rendered < maxVisible) {
-                    CatalogDropdown(
-                        spec = PrecomputedCatalog.Dropdowns.TUR_QUICK_LINKS,
-                        onEvent = onEvent,
-                        modifier = Modifier.widthIn(max = buttonWidth),
-                        maxPopupHeight = 130.dp,
-                    )
-                    rendered++
-                }
-                if (rendered < maxVisible) {
-                    CatalogDropdown(
-                        spec = PrecomputedCatalog.Dropdowns.SHULCHAN_ARUCH,
-                        onEvent = onEvent,
-                        modifier = Modifier.widthIn(max = buttonWidth),
-                        maxPopupHeight = 160.dp,
-                        popupWidthMultiplier = 1.1f,
-                    )
-                }
-            }
+            CatalogDropdown(
+                spec = PrecomputedCatalog.Dropdowns.TANAKH,
+                onEvent = onEvent,
+                modifier = buttonModifier,
+                popupWidthMultiplier = 1.50f,
+            )
+            CatalogDropdown(
+                spec = PrecomputedCatalog.Dropdowns.MISHNA,
+                onEvent = onEvent,
+                modifier = buttonModifier,
+            )
+            CatalogDropdown(
+                spec = PrecomputedCatalog.Dropdowns.BAVLI,
+                onEvent = onEvent,
+                modifier = buttonModifier,
+                popupWidthMultiplier = 1.1f,
+            )
+            CatalogDropdown(
+                spec = PrecomputedCatalog.Dropdowns.YERUSHALMI,
+                onEvent = onEvent,
+                modifier = buttonModifier,
+                popupWidthMultiplier = 1.1f,
+            )
+            CatalogDropdown(
+                spec = PrecomputedCatalog.Dropdowns.MISHNE_TORAH,
+                onEvent = onEvent,
+                modifier = buttonModifier,
+                popupWidthMultiplier = 1.5f,
+            )
+            CatalogDropdown(
+                spec = PrecomputedCatalog.Dropdowns.TUR_QUICK_LINKS,
+                onEvent = onEvent,
+                modifier = buttonModifier,
+                maxPopupHeight = 130.dp,
+            )
+            CatalogDropdown(
+                spec = PrecomputedCatalog.Dropdowns.SHULCHAN_ARUCH,
+                onEvent = onEvent,
+                modifier = buttonModifier,
+                maxPopupHeight = 160.dp,
+                popupWidthMultiplier = 1.1f,
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace `Row` + `BoxWithConstraints` button-hiding logic with `FlowRow` so all 7 catalog buttons are always visible and wrap to the next line when the panel is narrow
- Buttons remain centered and tightly spaced (max 130dp each), matching the previous visual style
- Removes the `BoxWithConstraints` double-measure pass, simplifying the layout

## Test plan
- [x] Verify all 7 catalog buttons are visible at any panel width
- [x] Verify buttons wrap to a second line when the panel is narrow
- [x] Verify buttons stay centered and tightly spaced when the panel is wide
- [x] Verify dropdown popups still open correctly after wrapping
- [x] Run `./gradlew :SeforimApp:jvmTest` — passes
- [x] Run `./gradlew ktlintCheck detekt` — passes