### PR TITLE
Replace Home graphicsLayer scaling with responsive layout

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/BookContentScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/BookContentScreen.kt
@@ -453,6 +453,7 @@ fun BookContentScreen(
         ) {
             StartVerticalBar(uiState = uiState, onEvent = onEvent)
 
+            val isHome = uiState.navigation.selectedBook == null
             val isIslands = ThemeUtils.isIslandsStyle()
             val panelCardModifier =
                 if (isIslands) {
@@ -500,7 +501,9 @@ fun BookContentScreen(
                 showSplitter = uiState.navigation.isVisible,
             )
 
-            EndVerticalBar(uiState = uiState, onEvent = onEvent, showDiacritics = showDiacritics)
+            if (!isHome) {
+                EndVerticalBar(uiState = uiState, onEvent = onEvent, showDiacritics = showDiacritics)
+            }
         }
     }
 

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/components/VerticalBars.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/components/VerticalBars.kt
@@ -33,15 +33,17 @@ fun StartVerticalBar(
                 label = stringResource(Res.string.books),
                 shortcutHint = if (PlatformInfo.isMacOS) "B+⌘" else "B+Ctrl",
             )
-            SelectableIconButtonWithToolip(
-                toolTipText = stringResource(Res.string.book_content),
-                onClick = { onEvent(BookContentEvent.ToggleToc) },
-                isSelected = uiState.toc.isVisible,
-                icon = TableOfContents,
-                iconDescription = stringResource(Res.string.table_of_contents),
-                label = stringResource(Res.string.table_of_contents),
-                shortcutHint = if (PlatformInfo.isMacOS) "B+⇧+⌘" else "B+Shift+Ctrl",
-            )
+            if (uiState.navigation.selectedBook != null) {
+                SelectableIconButtonWithToolip(
+                    toolTipText = stringResource(Res.string.book_content),
+                    onClick = { onEvent(BookContentEvent.ToggleToc) },
+                    isSelected = uiState.toc.isVisible,
+                    icon = TableOfContents,
+                    iconDescription = stringResource(Res.string.table_of_contents),
+                    label = stringResource(Res.string.table_of_contents),
+                    shortcutHint = if (PlatformInfo.isMacOS) "B+⇧+⌘" else "B+Shift+Ctrl",
+                )
+            }
         },
         bottomContent = {
 //            SelectableIconButtonWithToolip(
@@ -125,57 +127,60 @@ fun EndVerticalBar(
     VerticalLateralBar(
         position = VerticalLateralBarPosition.End,
         topContent = {
-            // Platform-specific shortcut hint for Zoom In
-            SelectableIconButtonWithToolip(
-                toolTipText =
-                    if (canZoomIn) {
-                        stringResource(Res.string.zoom_in_tooltip)
-                    } else {
-                        stringResource(Res.string.zoom_in_tooltip) + " (${AppSettings.MAX_TEXT_SIZE.toInt()}sp max)"
-                    },
-                onClick = { AppSettings.increaseTextSize() },
-                isSelected = false,
-                enabled = canZoomIn,
-                icon = ZoomIn,
-                iconDescription = stringResource(Res.string.zoom_in),
-                label = stringResource(Res.string.zoom_in),
-                shortcutHint = if (PlatformInfo.isMacOS) "+⌘" else "+Ctrl",
-            )
-            SelectableIconButtonWithToolip(
-                toolTipText =
-                    if (canZoomOut) {
-                        stringResource(Res.string.zoom_out_tooltip)
-                    } else {
-                        stringResource(Res.string.zoom_out_tooltip) + " (${AppSettings.MIN_TEXT_SIZE.toInt()}sp min)"
-                    },
-                onClick = { AppSettings.decreaseTextSize() },
-                isSelected = false,
-                enabled = canZoomOut,
-                icon = ZoomOut,
-                iconDescription = stringResource(Res.string.zoom_out),
-                label = stringResource(Res.string.zoom_out),
-                shortcutHint = if (PlatformInfo.isMacOS) "-⌘" else "-Ctrl",
-            )
-
-            // Diacritics toggle button - only show when book has nekudot or teamim
-            val bookHasDiacritics = selectedBook?.hasNekudot == true || selectedBook?.hasTeamim == true
-            if (bookHasDiacritics) {
+            // Hide zoom and diacritics buttons on Home (no book selected)
+            if (!noBookSelected) {
+                // Platform-specific shortcut hint for Zoom In
                 SelectableIconButtonWithToolip(
                     toolTipText =
-                        stringResource(
-                            if (showDiacritics) {
-                                Res.string.hide_diacritics_tooltip
-                            } else {
-                                Res.string.show_diacritics_tooltip
-                            },
-                        ),
-                    onClick = { onEvent(BookContentEvent.ToggleDiacritics) },
-                    isSelected = showDiacritics,
-                    icon = TextDiacritics,
-                    iconDescription = stringResource(Res.string.toggle_diacritics),
-                    label = stringResource(Res.string.toggle_diacritics),
-                    shortcutHint = if (PlatformInfo.isMacOS) "J+⌘" else "J+Ctrl",
+                        if (canZoomIn) {
+                            stringResource(Res.string.zoom_in_tooltip)
+                        } else {
+                            stringResource(Res.string.zoom_in_tooltip) + " (${AppSettings.MAX_TEXT_SIZE.toInt()}sp max)"
+                        },
+                    onClick = { AppSettings.increaseTextSize() },
+                    isSelected = false,
+                    enabled = canZoomIn,
+                    icon = ZoomIn,
+                    iconDescription = stringResource(Res.string.zoom_in),
+                    label = stringResource(Res.string.zoom_in),
+                    shortcutHint = if (PlatformInfo.isMacOS) "+⌘" else "+Ctrl",
                 )
+                SelectableIconButtonWithToolip(
+                    toolTipText =
+                        if (canZoomOut) {
+                            stringResource(Res.string.zoom_out_tooltip)
+                        } else {
+                            stringResource(Res.string.zoom_out_tooltip) + " (${AppSettings.MIN_TEXT_SIZE.toInt()}sp min)"
+                        },
+                    onClick = { AppSettings.decreaseTextSize() },
+                    isSelected = false,
+                    enabled = canZoomOut,
+                    icon = ZoomOut,
+                    iconDescription = stringResource(Res.string.zoom_out),
+                    label = stringResource(Res.string.zoom_out),
+                    shortcutHint = if (PlatformInfo.isMacOS) "-⌘" else "-Ctrl",
+                )
+
+                // Diacritics toggle button - only show when book has nekudot or teamim
+                val bookHasDiacritics = selectedBook?.hasNekudot == true || selectedBook?.hasTeamim == true
+                if (bookHasDiacritics) {
+                    SelectableIconButtonWithToolip(
+                        toolTipText =
+                            stringResource(
+                                if (showDiacritics) {
+                                    Res.string.hide_diacritics_tooltip
+                                } else {
+                                    Res.string.show_diacritics_tooltip
+                                },
+                            ),
+                        onClick = { onEvent(BookContentEvent.ToggleDiacritics) },
+                        isSelected = showDiacritics,
+                        icon = TextDiacritics,
+                        iconDescription = stringResource(Res.string.toggle_diacritics),
+                        label = stringResource(Res.string.toggle_diacritics),
+                        shortcutHint = if (PlatformInfo.isMacOS) "J+⌘" else "J+Ctrl",
+                    )
+                }
             }
 //            SelectableIconButtonWithToolip(
 //                toolTipText = stringResource(

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeView.kt
@@ -132,7 +132,11 @@ fun HomeView(
 ) {
     CatalogRow(onEvent = onEvent)
 
-    Box(modifier = modifier.fillMaxSize()) {
+    // Add end padding to compensate for the hidden EndVerticalBar on Home
+    val compactMode by AppSettings.compactModeFlow.collectAsState()
+    val endPadding = if (compactMode) 48.dp else 64.dp
+
+    Box(modifier = modifier.fillMaxSize().padding(end = endPadding)) {
         HomeBody(
             searchUi = searchUi,
             searchCallbacks = searchCallbacks,


### PR DESCRIPTION
## Summary

- Remove the `graphicsLayer` scaling system from `HomeBody` that composed content at a fixed 600dp width and visually scaled it down for smaller windows
- Replace with a true responsive layout using `widthIn(max = 600.dp).fillMaxWidth()` — content naturally fills available width up to 600dp, then centers
- Remove `parentScale` parameter from `SearchBar` and `ReferenceByCategorySection` along with the scaled popup positioning
- Make the logo scale proportionally on wide screens (30% of width, clamped between 220dp and 270dp)
- Hide `EndVerticalBar` (zoom, diacritics buttons) and TOC button on Home screen for a cleaner UI
- Add end padding to compensate for the hidden right vertical bar

Fixes #343

## Test plan

- [x] Launch app with window >= 600dp — appearance should be identical to before
- [x] Resize window below 600dp — content compresses naturally instead of scaling
- [x] Verify search suggestion popups display correctly at all widths
- [x] Verify logo grows slightly on very wide screens
- [x] Navigate to Home screen — vertical bars should be hidden, content should be padded
- [x] Open a book — vertical bars should appear immediately
- [x] Build passes: `./gradlew :SeforimApp:build`
- [x] Lint passes: `./gradlew :SeforimApp:ktlintCheck detekt`