### PR TITLE
feat: add F11 fullscreen toggle for Windows and Linux

### DIFF
--- a/SeforimApp/build.gradle.kts
+++ b/SeforimApp/build.gradle.kts
@@ -351,7 +351,6 @@ nucleus.application {
             packageVersion = macSafeVersion(version)
             packageName = "זית"
             appStore = true
-
         }
         buildTypes.release.proguard {
             version.set("7.9.0")

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/database/update/DatabaseUpdateWindow.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/database/update/DatabaseUpdateWindow.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ApplicationScope
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
@@ -49,8 +48,6 @@ fun ApplicationScope.DatabaseUpdateWindow(
         visible = true,
         resizable = false,
     ) {
-
-
         val windowViewModelOwner = rememberWindowViewModelStoreOwner()
         CompositionLocalProvider(
             LocalWindowViewModelStoreOwner provides windowViewModelOwner,
@@ -67,7 +64,11 @@ fun ApplicationScope.DatabaseUpdateWindow(
                 }
             }
 
-            JewelTitleBar(modifier = Modifier.newFullscreenControls(), gradientStartColor = ThemeUtils.titleBarGradientColor(), controlButtonsDirection = ControlButtonsDirection.SystemNative) {
+            JewelTitleBar(
+                modifier = Modifier.newFullscreenControls(),
+                gradientStartColor = ThemeUtils.titleBarGradientColor(),
+                controlButtonsDirection = ControlButtonsDirection.SystemNative,
+            ) {
                 // Keep the back button pinned to the start and
                 // center the title (icon + text) regardless of OS/window controls.
                 Box(

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/onboarding/OnBoardingWindow.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/onboarding/OnBoardingWindow.kt
@@ -65,7 +65,11 @@ fun ApplicationScope.OnBoardingWindow() {
                     canNavigateBack = navController.previousBackStackEntry != null
                 }
             }
-            JewelTitleBar(modifier = Modifier.newFullscreenControls(), gradientStartColor = ThemeUtils.titleBarGradientColor(), controlButtonsDirection = ControlButtonsDirection.SystemNative) {
+            JewelTitleBar(
+                modifier = Modifier.newFullscreenControls(),
+                gradientStartColor = ThemeUtils.titleBarGradientColor(),
+                controlButtonsDirection = ControlButtonsDirection.SystemNative,
+            ) {
                 // Keep the back button pinned to the start and
                 // center the title (icon + text) regardless of OS/window controls.
                 Box(

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/SettingsWindow.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/SettingsWindow.kt
@@ -66,88 +66,88 @@ private fun SettingsWindowView(onClose: () -> Unit) {
             visible = true,
             resizable = true,
         ) {
-                val background = JewelTheme.globalColors.panelBackground
-                LaunchedEffect(window, background) { window.background = java.awt.Color(background.toArgb()) }
+            val background = JewelTheme.globalColors.panelBackground
+            LaunchedEffect(window, background) { window.background = java.awt.Color(background.toArgb()) }
 
-                val windowViewModelOwner = rememberWindowViewModelStoreOwner()
-                CompositionLocalProvider(
-                    LocalWindowViewModelStoreOwner provides windowViewModelOwner,
-                    LocalViewModelStoreOwner provides windowViewModelOwner,
+            val windowViewModelOwner = rememberWindowViewModelStoreOwner()
+            CompositionLocalProvider(
+                LocalWindowViewModelStoreOwner provides windowViewModelOwner,
+                LocalViewModelStoreOwner provides windowViewModelOwner,
+            ) {
+                JewelDialogTitleBar(
+                    modifier = Modifier.newFullscreenControls(),
+                    gradientStartColor = if (ThemeUtils.isIslandsStyle()) ThemeUtils.titleBarGradientColor() else Color.Unspecified,
+                    controlButtonsDirection = ControlButtonsDirection.SystemNative,
                 ) {
-                    JewelDialogTitleBar(
-                        modifier = Modifier.newFullscreenControls(),
-                        gradientStartColor = if (ThemeUtils.isIslandsStyle()) ThemeUtils.titleBarGradientColor() else Color.Unspecified,
-                        controlButtonsDirection = ControlButtonsDirection.SystemNative,
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
-                            Icon(
-                                AllIconsKeys.General.Settings,
-                                contentDescription = null,
-                                tint = JewelTheme.globalColors.text.normal,
-                                modifier = Modifier.size(16.dp),
-                            )
-                            Text(stringResource(Res.string.settings))
-                        }
+                        Icon(
+                            AllIconsKeys.General.Settings,
+                            contentDescription = null,
+                            tint = JewelTheme.globalColors.text.normal,
+                            modifier = Modifier.size(16.dp),
+                        )
+                        Text(stringResource(Res.string.settings))
                     }
-                    // IntelliJ-like layout: sidebar + content with header and bottom action bar
-                    val navController = rememberNavController()
-                    Column(
-                        modifier =
-                            Modifier
-                                .trackActivation()
-                                .fillMaxSize()
-                                .background(JewelTheme.globalColors.panelBackground)
-                                .padding(16.dp),
-                    ) {
-                        Row(modifier = Modifier.weight(1f)) {
-                            SettingsSidebar(
-                                modifier =
-                                    Modifier
-                                        .fillMaxHeight()
-                                        .width(120.dp),
-                                navController = navController,
-                            )
+                }
+                // IntelliJ-like layout: sidebar + content with header and bottom action bar
+                val navController = rememberNavController()
+                Column(
+                    modifier =
+                        Modifier
+                            .trackActivation()
+                            .fillMaxSize()
+                            .background(JewelTheme.globalColors.panelBackground)
+                            .padding(16.dp),
+                ) {
+                    Row(modifier = Modifier.weight(1f)) {
+                        SettingsSidebar(
+                            modifier =
+                                Modifier
+                                    .fillMaxHeight()
+                                    .width(120.dp),
+                            navController = navController,
+                        )
 
-                            // Vertical separator between the menu and content
-                            Divider(
-                                orientation = Orientation.Vertical,
-                                color = JewelTheme.globalColors.borders.disabled,
-                                modifier =
-                                    Modifier
-                                        .fillMaxHeight()
-                                        .padding(horizontal = 8.dp),
-                            )
+                        // Vertical separator between the menu and content
+                        Divider(
+                            orientation = Orientation.Vertical,
+                            color = JewelTheme.globalColors.borders.disabled,
+                            modifier =
+                                Modifier
+                                    .fillMaxHeight()
+                                    .padding(horizontal = 8.dp),
+                        )
 
-                            Column(
-                                modifier =
-                                    Modifier
-                                        .weight(1f)
-                                        .fillMaxHeight()
-                                        .padding(start = 16.dp),
-                            ) {
-                                Box(modifier = Modifier.weight(1f)) {
-                                    SettingsNavHost(navController = navController)
-                                }
+                        Column(
+                            modifier =
+                                Modifier
+                                    .weight(1f)
+                                    .fillMaxHeight()
+                                    .padding(start = 16.dp),
+                        ) {
+                            Box(modifier = Modifier.weight(1f)) {
+                                SettingsNavHost(navController = navController)
                             }
                         }
+                    }
 
-                        Spacer(Modifier.height(8.dp))
-                        Divider(orientation = Orientation.Horizontal)
-                        Spacer(Modifier.height(8.dp))
+                    Spacer(Modifier.height(8.dp))
+                    Divider(orientation = Orientation.Horizontal)
+                    Spacer(Modifier.height(8.dp))
 
-                        // Bottom action bar aligned to the end
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.End,
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            DefaultButton(onClick = onClose) { Text(stringResource(Res.string.settings_close)) }
-                        }
+                    // Bottom action bar aligned to the end
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        DefaultButton(onClick = onClose) { Text(stringResource(Res.string.settings_close)) }
                     }
                 }
             }
+        }
     }
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/GeneralSettingsScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/GeneralSettingsScreen.kt
@@ -51,8 +51,8 @@ import seforimapp.seforimapp.generated.resources.Res
 import seforimapp.seforimapp.generated.resources.close_book_tree_on_new_book
 import seforimapp.seforimapp.generated.resources.close_book_tree_on_new_book_description
 import seforimapp.seforimapp.generated.resources.settings_info_app_version
-import seforimapp.seforimapp.generated.resources.settings_info_jdk_version
 import seforimapp.seforimapp.generated.resources.settings_info_created_by
+import seforimapp.seforimapp.generated.resources.settings_info_jdk_version
 import seforimapp.seforimapp.generated.resources.settings_info_license
 import seforimapp.seforimapp.generated.resources.settings_info_license_usage
 import seforimapp.seforimapp.generated.resources.settings_persist_session
@@ -186,13 +186,14 @@ private fun AppHeader(
                     color = JewelTheme.globalColors.text.info,
                 )
                 Text(
-                    text = stringResource(
-                        Res.string.settings_info_jdk_version,
-                        System.getProperty("java.runtime.name", "Unknown"),
-                        System.getProperty("java.version", "?"),
-                        System.getProperty("java.vendor", "Unknown"),
-                        System.getProperty("os.arch", "?"),
-                    ),
+                    text =
+                        stringResource(
+                            Res.string.settings_info_jdk_version,
+                            System.getProperty("java.runtime.name", "Unknown"),
+                            System.getProperty("java.version", "?"),
+                            System.getProperty("java.vendor", "Unknown"),
+                            System.getProperty("os.arch", "?"),
+                        ),
                     fontSize = 13.sp,
                     color = JewelTheme.globalColors.text.info,
                 )

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/main.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/main.kt
@@ -233,293 +233,291 @@ fun main() {
                 theme = themeDefinition,
                 styling = componentStyling,
             ) {
-                    if (showOnboarding) {
-                        OnBoardingWindow()
-                    } else if (showDatabaseUpdate) {
-                        DatabaseUpdateWindow(
-                            onUpdateComplete = {
-                                // After database update, refresh the version check and show main app
-                                showDatabaseUpdate = false
+                if (showOnboarding) {
+                    OnBoardingWindow()
+                } else if (showDatabaseUpdate) {
+                    DatabaseUpdateWindow(
+                        onUpdateComplete = {
+                            // After database update, refresh the version check and show main app
+                            showDatabaseUpdate = false
+                        },
+                        isDatabaseMissing = isDatabaseMissing,
+                    )
+                } else {
+                    val windowViewModelOwner = rememberWindowViewModelStoreOwner()
+                    val settingsWindowViewModel: SettingsWindowViewModel =
+                        metroViewModel(viewModelStoreOwner = windowViewModelOwner)
+
+                    // Build dynamic window title: "AppName - [DesktopName] - CurrentTab"
+                    val tabsVm = appGraph.tabsViewModel
+                    val desktopMgr = appGraph.desktopManager
+                    val tabsState by tabsVm.state.collectAsState()
+                    val tabs = tabsState.tabs
+                    val selectedIndex = tabsState.selectedTabIndex
+                    val allDesktops by desktopMgr.desktops.collectAsState()
+                    val currentDesktopId by desktopMgr.activeDesktopId.collectAsState()
+                    val currentDesktopName = allDesktops.find { it.id == currentDesktopId }?.name
+                    val nextDesktopName =
+                        stringResource(
+                            Res.string.desktop_default_name,
+                            remember(allDesktops.size) {
+                                (allDesktops.size + 1).toHebrewNumeral(includeGeresh = false) + "׳"
                             },
-                            isDatabaseMissing = isDatabaseMissing,
                         )
-                    } else {
-                        val windowViewModelOwner = rememberWindowViewModelStoreOwner()
-                        val settingsWindowViewModel: SettingsWindowViewModel =
-                            metroViewModel(viewModelStoreOwner = windowViewModelOwner)
-
-                        // Build dynamic window title: "AppName - [DesktopName] - CurrentTab"
-                        val tabsVm = appGraph.tabsViewModel
-                        val desktopMgr = appGraph.desktopManager
-                        val tabsState by tabsVm.state.collectAsState()
-                        val tabs = tabsState.tabs
-                        val selectedIndex = tabsState.selectedTabIndex
-                        val allDesktops by desktopMgr.desktops.collectAsState()
-                        val currentDesktopId by desktopMgr.activeDesktopId.collectAsState()
-                        val currentDesktopName = allDesktops.find { it.id == currentDesktopId }?.name
-                        val nextDesktopName =
-                            stringResource(
-                                Res.string.desktop_default_name,
-                                remember(allDesktops.size) {
-                                    (allDesktops.size + 1).toHebrewNumeral(includeGeresh = false) + "׳"
-                                },
-                            )
-                        val appTitle = stringResource(Res.string.app_name)
-                        val selectedTab = tabs.getOrNull(selectedIndex)
-                        val rawTitle = selectedTab?.title.orEmpty()
-                        val tabType = selectedTab?.tabType
-                        val formattedTabTitle =
-                            when {
-                                rawTitle.isEmpty() -> stringResource(Res.string.home)
-                                tabType == TabType.SEARCH -> stringResource(Res.string.search_results_tab_title, rawTitle)
-                                else -> rawTitle
+                    val appTitle = stringResource(Res.string.app_name)
+                    val selectedTab = tabs.getOrNull(selectedIndex)
+                    val rawTitle = selectedTab?.title.orEmpty()
+                    val tabType = selectedTab?.tabType
+                    val formattedTabTitle =
+                        when {
+                            rawTitle.isEmpty() -> stringResource(Res.string.home)
+                            tabType == TabType.SEARCH -> stringResource(Res.string.search_results_tab_title, rawTitle)
+                            else -> rawTitle
+                        }
+                    val windowTitle =
+                        buildString {
+                            append(appTitle)
+                            if (allDesktops.size > 1 && currentDesktopName != null) {
+                                append(" - [$currentDesktopName]")
                             }
-                        val windowTitle =
-                            buildString {
-                                append(appTitle)
-                                if (allDesktops.size > 1 && currentDesktopName != null) {
-                                    append(" - [$currentDesktopName]")
-                                }
-                                if (formattedTabTitle.isNotBlank()) {
-                                    append(" - $formattedTabTitle")
-                                }
+                            if (formattedTabTitle.isNotBlank()) {
+                                append(" - $formattedTabTitle")
                             }
+                        }
 
-                        JewelDecoratedWindow(
-                            onCloseRequest = {
-                                // Persist session if enabled, then exit
-                                SessionManager.saveIfEnabled(appGraph)
-                                exitApplication()
-                            },
-                            title = windowTitle,
-                            icon = if (PlatformInfo.isMacOS) null else painterResource(Res.drawable.AppIcon),
-                            state = windowState,
-                            visible = isWindowVisible,
-                            onKeyEvent = { keyEvent ->
-                                if (keyEvent.type == KeyEventType.KeyDown) {
-                                    // Read fresh state to avoid stale captures in cached lambda
-                                    val currentState = tabsVm.state.value
-                                    val currentTabs = currentState.tabs
-                                    val currentIndex = currentState.selectedTabIndex
-                                    val isCtrlOrCmd = keyEvent.isCtrlPressed || keyEvent.isMetaPressed
-                                    if (isCtrlOrCmd && keyEvent.key == Key.T) {
-                                        tabsVm.onEvent(TabsEvents.OnAdd)
+                    JewelDecoratedWindow(
+                        onCloseRequest = {
+                            // Persist session if enabled, then exit
+                            SessionManager.saveIfEnabled(appGraph)
+                            exitApplication()
+                        },
+                        title = windowTitle,
+                        icon = if (PlatformInfo.isMacOS) null else painterResource(Res.drawable.AppIcon),
+                        state = windowState,
+                        visible = isWindowVisible,
+                        onKeyEvent = { keyEvent ->
+                            if (keyEvent.type == KeyEventType.KeyDown) {
+                                // Read fresh state to avoid stale captures in cached lambda
+                                val currentState = tabsVm.state.value
+                                val currentTabs = currentState.tabs
+                                val currentIndex = currentState.selectedTabIndex
+                                val isCtrlOrCmd = keyEvent.isCtrlPressed || keyEvent.isMetaPressed
+                                if (isCtrlOrCmd && keyEvent.key == Key.T) {
+                                    tabsVm.onEvent(TabsEvents.OnAdd)
+                                    true
+                                } else if (isCtrlOrCmd && keyEvent.key == Key.W) {
+                                    tabsVm.onEvent(TabsEvents.OnClose(currentIndex))
+                                    true
+                                } else if (isCtrlOrCmd && keyEvent.key == Key.Tab) {
+                                    val count = currentTabs.size
+                                    if (count > 0) {
+                                        val direction = if (keyEvent.isShiftPressed) -1 else 1
+                                        val newIndex = (currentIndex + direction + count) % count
+                                        tabsVm.onEvent(TabsEvents.OnSelect(newIndex))
+                                    }
+                                    true
+                                } else if ((keyEvent.isAltPressed && keyEvent.key == Key.Home) ||
+                                    (keyEvent.isMetaPressed && keyEvent.isShiftPressed && keyEvent.key == Key.H)
+                                ) {
+                                    val currentTabId = currentTabs.getOrNull(currentIndex)?.destination?.tabId
+                                    if (currentTabId != null) {
+                                        tabsVm.replaceCurrentTabWithNewTabId(TabsDestination.Home(currentTabId))
                                         true
-                                    } else if (isCtrlOrCmd && keyEvent.key == Key.W) {
-                                        tabsVm.onEvent(TabsEvents.OnClose(currentIndex))
-                                        true
-                                    } else if (isCtrlOrCmd && keyEvent.key == Key.Tab) {
-                                        val count = currentTabs.size
-                                        if (count > 0) {
-                                            val direction = if (keyEvent.isShiftPressed) -1 else 1
-                                            val newIndex = (currentIndex + direction + count) % count
-                                            tabsVm.onEvent(TabsEvents.OnSelect(newIndex))
-                                        }
-                                        true
-                                    } else if ((keyEvent.isAltPressed && keyEvent.key == Key.Home) ||
-                                        (keyEvent.isMetaPressed && keyEvent.isShiftPressed && keyEvent.key == Key.H)
-                                    ) {
-                                        val currentTabId = currentTabs.getOrNull(currentIndex)?.destination?.tabId
-                                        if (currentTabId != null) {
-                                            tabsVm.replaceCurrentTabWithNewTabId(TabsDestination.Home(currentTabId))
-                                            true
+                                    } else {
+                                        false
+                                    }
+                                } else if (isCtrlOrCmd && keyEvent.key == Key.Comma) {
+                                    settingsWindowViewModel.onEvent(SettingsWindowEvents.OnOpen)
+                                    true
+                                } else if (PlatformInfo.isMacOS && keyEvent.isMetaPressed && keyEvent.key == Key.M) {
+                                    windowState.isMinimized = true
+                                    true
+                                } else if (!PlatformInfo.isMacOS && keyEvent.key == Key.F11) {
+                                    windowState.placement =
+                                        if (windowState.placement == WindowPlacement.Fullscreen) {
+                                            WindowPlacement.Maximized
                                         } else {
-                                            false
+                                            WindowPlacement.Fullscreen
                                         }
-                                    } else if (isCtrlOrCmd && keyEvent.key == Key.Comma) {
-                                        settingsWindowViewModel.onEvent(SettingsWindowEvents.OnOpen)
-                                        true
-                                    } else if (PlatformInfo.isMacOS && keyEvent.isMetaPressed && keyEvent.key == Key.M) {
-                                        windowState.isMinimized = true
-                                        true
-                                    } else if (!PlatformInfo.isMacOS && keyEvent.key == Key.F11) {
-                                        windowState.placement =
-                                            if (windowState.placement == WindowPlacement.Fullscreen) {
-                                                WindowPlacement.Maximized
-                                            } else {
-                                                WindowPlacement.Fullscreen
-                                            }
-                                        true
-                                    } else {
-                                        processKeyShortcuts(
-                                            keyEvent = keyEvent,
-                                            onNavigateTo = { /* no-op: legacy shortcuts not used here */ },
-                                            tabId = currentTabs.getOrNull(currentIndex)?.destination?.tabId ?: "",
-                                        )
-                                    }
+                                    true
                                 } else {
-                                    false
+                                    processKeyShortcuts(
+                                        keyEvent = keyEvent,
+                                        onNavigateTo = { /* no-op: legacy shortcuts not used here */ },
+                                        tabId = currentTabs.getOrNull(currentIndex)?.destination?.tabId ?: "",
+                                    )
                                 }
-                            },
+                            } else {
+                                false
+                            }
+                        },
+                    ) {
+                        CompositionLocalProvider(
+                            LocalLayoutDirection provides LayoutDirection.Rtl,
+                            LocalWindowViewModelStoreOwner provides windowViewModelOwner,
+                            LocalViewModelStoreOwner provides windowViewModelOwner,
                         ) {
-                            CompositionLocalProvider(
-                                LocalLayoutDirection provides LayoutDirection.Rtl,
-                                LocalWindowViewModelStoreOwner provides windowViewModelOwner,
-                                LocalViewModelStoreOwner provides windowViewModelOwner,
-                            ) {
-
-                                LaunchedEffect(Unit) {
-                                    window.minimumSize = Dimension(600, 300)
+                            LaunchedEffect(Unit) {
+                                window.minimumSize = Dimension(600, 300)
+                            }
+                            MainTitleBar()
+                            LaunchedEffect(state.isMinimized) {
+                                if (state.isMinimized) {
+                                    EnergyManager.enableEfficiencyMode()
+                                } else {
+                                    EnergyManager.disableEfficiencyMode()
                                 }
-                                MainTitleBar()
-                                LaunchedEffect(state.isMinimized) {
-                                    if (state.isMinimized) {
-                                        EnergyManager.enableEfficiencyMode()
-                                    } else {
-                                        EnergyManager.disableEfficiencyMode()
-                                    }
-                                }
+                            }
 
-                                // Restore previously saved session once when main window becomes active
-                                var sessionRestored by remember { mutableStateOf(false) }
-                                LaunchedEffect(Unit) {
-                                    if (!sessionRestored) {
-                                        SessionManager.restoreIfEnabled(appGraph)
-                                        sessionRestored = true
-                                    }
+                            // Restore previously saved session once when main window becomes active
+                            var sessionRestored by remember { mutableStateOf(false) }
+                            LaunchedEffect(Unit) {
+                                if (!sessionRestored) {
+                                    SessionManager.restoreIfEnabled(appGraph)
+                                    sessionRestored = true
                                 }
-                                // Check for updates once at startup
-                                val updateNotificationTitle = stringResource(Res.string.update_available_toast)
-                                val updateNotificationMessage = stringResource(Res.string.update_notification_message)
-                                val updateNotificationButton = stringResource(Res.string.update_download_action)
-                                LaunchedEffect(Unit) {
-                                    if (!mainAppState.updateCheckDone.value) {
-                                        when (val result = AppUpdateChecker.checkForUpdate()) {
-                                            is AppUpdateChecker.UpdateCheckResult.UpdateAvailable -> {
-                                                if (true) return@LaunchedEffect
-                                                mainAppState.setUpdateAvailable(result.latestVersion)
+                            }
+                            // Check for updates once at startup
+                            val updateNotificationTitle = stringResource(Res.string.update_available_toast)
+                            val updateNotificationMessage = stringResource(Res.string.update_notification_message)
+                            val updateNotificationButton = stringResource(Res.string.update_download_action)
+                            LaunchedEffect(Unit) {
+                                if (!mainAppState.updateCheckDone.value) {
+                                    when (val result = AppUpdateChecker.checkForUpdate()) {
+                                        is AppUpdateChecker.UpdateCheckResult.UpdateAvailable -> {
+                                            if (true) return@LaunchedEffect
+                                            mainAppState.setUpdateAvailable(result.latestVersion)
 
-                                                if (!ExecutableRuntime.isDev()) {
-                                                    // Send system notification
-                                                    notification(
-                                                        title = updateNotificationTitle,
-                                                        message = updateNotificationMessage,
-                                                        largeIcon = {
-                                                            Image(
-                                                                painter = painterResource(Res.drawable.AppIcon),
-                                                                contentDescription = null,
-                                                                modifier = Modifier.fillMaxSize(),
-                                                            )
-                                                        },
-                                                        onActivated = {
-                                                            Desktop.getDesktop().browse(URI(AppUpdateChecker.DOWNLOAD_URL))
-                                                        },
-                                                    ) {
-                                                        button(title = updateNotificationButton) {
-                                                            Desktop.getDesktop().browse(URI(AppUpdateChecker.DOWNLOAD_URL))
-                                                        }
-                                                    }.send()
-                                                }
+                                            if (!ExecutableRuntime.isDev()) {
+                                                // Send system notification
+                                                notification(
+                                                    title = updateNotificationTitle,
+                                                    message = updateNotificationMessage,
+                                                    largeIcon = {
+                                                        Image(
+                                                            painter = painterResource(Res.drawable.AppIcon),
+                                                            contentDescription = null,
+                                                            modifier = Modifier.fillMaxSize(),
+                                                        )
+                                                    },
+                                                    onActivated = {
+                                                        Desktop.getDesktop().browse(URI(AppUpdateChecker.DOWNLOAD_URL))
+                                                    },
+                                                ) {
+                                                    button(title = updateNotificationButton) {
+                                                        Desktop.getDesktop().browse(URI(AppUpdateChecker.DOWNLOAD_URL))
+                                                    }
+                                                }.send()
                                             }
-                                            is AppUpdateChecker.UpdateCheckResult.UpToDate -> {
-                                                mainAppState.markUpdateCheckDone()
-                                            }
-                                            is AppUpdateChecker.UpdateCheckResult.Error -> {
-                                                mainAppState.markUpdateCheckDone()
-                                            }
+                                        }
+                                        is AppUpdateChecker.UpdateCheckResult.UpToDate -> {
+                                            mainAppState.markUpdateCheckDone()
+                                        }
+                                        is AppUpdateChecker.UpdateCheckResult.Error -> {
+                                            mainAppState.markUpdateCheckDone()
                                         }
                                     }
                                 }
-
-                                // Intercept key combos early to avoid focus traversal consuming Tab
-                                Box(
-                                    modifier =
-                                        Modifier
-                                            .fillMaxSize()
-                                            .onPreviewKeyEvent { keyEvent ->
-                                                if (keyEvent.type == KeyEventType.KeyDown) {
-                                                    val isCtrlOrCmd = keyEvent.isCtrlPressed || keyEvent.isMetaPressed
-                                                    when {
-                                                        // Ctrl/Cmd + W => close current tab
-                                                        isCtrlOrCmd && keyEvent.key == Key.W -> {
-                                                            tabsVm.onEvent(TabsEvents.OnClose(selectedIndex))
-                                                            true
-                                                        }
-                                                        // Ctrl/Cmd + Shift + Tab => previous tab
-                                                        isCtrlOrCmd && keyEvent.key == Key.Tab && keyEvent.isShiftPressed -> {
-                                                            val count = tabs.size
-                                                            if (count > 0) {
-                                                                val newIndex = (selectedIndex - 1 + count) % count
-                                                                tabsVm.onEvent(TabsEvents.OnSelect(newIndex))
-                                                            }
-                                                            true
-                                                        }
-                                                        // Ctrl/Cmd + Tab => next tab
-                                                        isCtrlOrCmd && keyEvent.key == Key.Tab -> {
-                                                            val count = tabs.size
-                                                            if (count > 0) {
-                                                                val newIndex = (selectedIndex + 1) % count
-                                                                tabsVm.onEvent(TabsEvents.OnSelect(newIndex))
-                                                            }
-                                                            true
-                                                        }
-                                                        // Ctrl/Cmd + T => new tab
-                                                        isCtrlOrCmd && keyEvent.key == Key.T -> {
-                                                            tabsVm.onEvent(TabsEvents.OnAdd)
-                                                            true
-                                                        }
-                                                        // Alt + Home (Windows) or Cmd + Shift + H (macOS) => go Home on current tab
-                                                        (keyEvent.isAltPressed && keyEvent.key == Key.Home) ||
-                                                            (
-                                                                keyEvent.isMetaPressed &&
-                                                                    keyEvent.isShiftPressed &&
-                                                                    keyEvent.key == Key.H
-                                                            ) -> {
-                                                            val currentTabId = tabs.getOrNull(selectedIndex)?.destination?.tabId
-                                                            if (currentTabId != null) {
-                                                                tabsVm.replaceCurrentTabWithNewTabId(TabsDestination.Home(currentTabId))
-                                                                true
-                                                            } else {
-                                                                false
-                                                            }
-                                                        }
-                                                        // Ctrl/Cmd + Comma => open settings
-                                                        isCtrlOrCmd && keyEvent.key == Key.Comma -> {
-                                                            settingsWindowViewModel.onEvent(SettingsWindowEvents.OnOpen)
-                                                            true
-                                                        }
-                                                        // Ctrl/Cmd + Alt + Right => next desktop
-                                                        isCtrlOrCmd && keyEvent.isAltPressed && keyEvent.key == Key.DirectionRight -> {
-                                                            desktopMgr.switchToNext()
-                                                            true
-                                                        }
-                                                        // Ctrl/Cmd + Alt + Left => previous desktop
-                                                        isCtrlOrCmd && keyEvent.isAltPressed && keyEvent.key == Key.DirectionLeft -> {
-                                                            desktopMgr.switchToPrevious()
-                                                            true
-                                                        }
-                                                        // Ctrl/Cmd + Alt + N => new desktop
-                                                        isCtrlOrCmd && keyEvent.isAltPressed && keyEvent.key == Key.N -> {
-                                                            desktopMgr.createDesktop(nextDesktopName)
-                                                            true
-                                                        }
-                                                        // Cmd + M => minimize window (macOS only)
-                                                        PlatformInfo.isMacOS && keyEvent.isMetaPressed && keyEvent.key == Key.M -> {
-                                                            windowState.isMinimized = true
-                                                            true
-                                                        }
-                                                        // F11 => toggle fullscreen (Windows/Linux only)
-                                                        !PlatformInfo.isMacOS && keyEvent.key == Key.F11 -> {
-                                                            windowState.placement =
-                                                                if (windowState.placement == WindowPlacement.Fullscreen) {
-                                                                    WindowPlacement.Maximized
-                                                                } else {
-                                                                    WindowPlacement.Fullscreen
-                                                                }
-                                                            true
-                                                        }
-                                                        else -> false
-                                                    }
-                                                } else {
-                                                    false
-                                                }
-                                            },
-                                ) { TabsContent() }
                             }
+
+                            // Intercept key combos early to avoid focus traversal consuming Tab
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .fillMaxSize()
+                                        .onPreviewKeyEvent { keyEvent ->
+                                            if (keyEvent.type == KeyEventType.KeyDown) {
+                                                val isCtrlOrCmd = keyEvent.isCtrlPressed || keyEvent.isMetaPressed
+                                                when {
+                                                    // Ctrl/Cmd + W => close current tab
+                                                    isCtrlOrCmd && keyEvent.key == Key.W -> {
+                                                        tabsVm.onEvent(TabsEvents.OnClose(selectedIndex))
+                                                        true
+                                                    }
+                                                    // Ctrl/Cmd + Shift + Tab => previous tab
+                                                    isCtrlOrCmd && keyEvent.key == Key.Tab && keyEvent.isShiftPressed -> {
+                                                        val count = tabs.size
+                                                        if (count > 0) {
+                                                            val newIndex = (selectedIndex - 1 + count) % count
+                                                            tabsVm.onEvent(TabsEvents.OnSelect(newIndex))
+                                                        }
+                                                        true
+                                                    }
+                                                    // Ctrl/Cmd + Tab => next tab
+                                                    isCtrlOrCmd && keyEvent.key == Key.Tab -> {
+                                                        val count = tabs.size
+                                                        if (count > 0) {
+                                                            val newIndex = (selectedIndex + 1) % count
+                                                            tabsVm.onEvent(TabsEvents.OnSelect(newIndex))
+                                                        }
+                                                        true
+                                                    }
+                                                    // Ctrl/Cmd + T => new tab
+                                                    isCtrlOrCmd && keyEvent.key == Key.T -> {
+                                                        tabsVm.onEvent(TabsEvents.OnAdd)
+                                                        true
+                                                    }
+                                                    // Alt + Home (Windows) or Cmd + Shift + H (macOS) => go Home on current tab
+                                                    (keyEvent.isAltPressed && keyEvent.key == Key.Home) ||
+                                                        (
+                                                            keyEvent.isMetaPressed &&
+                                                                keyEvent.isShiftPressed &&
+                                                                keyEvent.key == Key.H
+                                                        ) -> {
+                                                        val currentTabId = tabs.getOrNull(selectedIndex)?.destination?.tabId
+                                                        if (currentTabId != null) {
+                                                            tabsVm.replaceCurrentTabWithNewTabId(TabsDestination.Home(currentTabId))
+                                                            true
+                                                        } else {
+                                                            false
+                                                        }
+                                                    }
+                                                    // Ctrl/Cmd + Comma => open settings
+                                                    isCtrlOrCmd && keyEvent.key == Key.Comma -> {
+                                                        settingsWindowViewModel.onEvent(SettingsWindowEvents.OnOpen)
+                                                        true
+                                                    }
+                                                    // Ctrl/Cmd + Alt + Right => next desktop
+                                                    isCtrlOrCmd && keyEvent.isAltPressed && keyEvent.key == Key.DirectionRight -> {
+                                                        desktopMgr.switchToNext()
+                                                        true
+                                                    }
+                                                    // Ctrl/Cmd + Alt + Left => previous desktop
+                                                    isCtrlOrCmd && keyEvent.isAltPressed && keyEvent.key == Key.DirectionLeft -> {
+                                                        desktopMgr.switchToPrevious()
+                                                        true
+                                                    }
+                                                    // Ctrl/Cmd + Alt + N => new desktop
+                                                    isCtrlOrCmd && keyEvent.isAltPressed && keyEvent.key == Key.N -> {
+                                                        desktopMgr.createDesktop(nextDesktopName)
+                                                        true
+                                                    }
+                                                    // Cmd + M => minimize window (macOS only)
+                                                    PlatformInfo.isMacOS && keyEvent.isMetaPressed && keyEvent.key == Key.M -> {
+                                                        windowState.isMinimized = true
+                                                        true
+                                                    }
+                                                    // F11 => toggle fullscreen (Windows/Linux only)
+                                                    !PlatformInfo.isMacOS && keyEvent.key == Key.F11 -> {
+                                                        windowState.placement =
+                                                            if (windowState.placement == WindowPlacement.Fullscreen) {
+                                                                WindowPlacement.Maximized
+                                                            } else {
+                                                                WindowPlacement.Fullscreen
+                                                            }
+                                                        true
+                                                    }
+                                                    else -> false
+                                                }
+                                            } else {
+                                                false
+                                            }
+                                        },
+                            ) { TabsContent() }
                         }
                     }
                 }
             }
         }
-
+    }
 }


### PR DESCRIPTION
## Summary
- Add F11 keyboard shortcut to toggle fullscreen on Windows and Linux
- Toggles between `WindowPlacement.Fullscreen` and `WindowPlacement.Maximized`
- Handled in both `onKeyEvent` (window-level) and `onPreviewKeyEvent` (content-level) for reliable capture
- Skipped on macOS where native fullscreen is managed by the system

Fixes #117

## Test plan
- [x] Press F11 on Windows → window enters fullscreen
- [x] Press F11 again → window returns to maximized
- [x] Verify F11 has no effect on macOS
- [x] Verify other keyboard shortcuts still work correctly