### PR TITLE
Use user accent color in celestial home widgets

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeCelestialWidgets.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeCelestialWidgets.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -63,6 +64,7 @@ import io.github.kdroidfilter.seforimapp.earthwidget.computeZmanimTimes
 import io.github.kdroidfilter.seforimapp.earthwidget.timeZoneForLocation
 import io.github.kdroidfilter.seforimapp.features.onboarding.userprofile.Community
 import io.github.kdroidfilter.seforimapp.features.zmanim.data.worldPlaces
+import io.github.kdroidfilter.seforimapp.framework.di.LocalAppGraph
 import io.github.kdroidfilter.seforimapp.theme.PreviewContainer
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -237,6 +239,17 @@ fun HomeCelestialWidgets(
     modifier: Modifier = Modifier,
     userCommunityCode: String? = null,
 ) {
+    val isDark = JewelTheme.isDark
+    val accentColor =
+        LocalAppGraph.current.mainAppState.accentColor
+            .collectAsState()
+            .value
+    val accent = accentColor.resolveColor(isDark)
+    // Convert accent color to 0x00RRGGBB for the pixel-level orbit renderer
+    val accentRgbInt =
+        ((accent.red * 255).toInt() shl 16) or
+            ((accent.green * 255).toInt() shl 8) or
+            (accent.blue * 255).toInt()
     val userPlace = locationState.userPlace
     val userCityLabel = locationState.userCityLabel
     val userCommunity =
@@ -608,6 +621,7 @@ fun HomeCelestialWidgets(
                                 locationOptions = locationOptions,
                                 kiddushLevanaEarliestOpinion = kiddushLevanaEarliestOpinion,
                                 kiddushLevanaLatestOpinion = kiddushLevanaLatestOpinion,
+                                kiddushLevanaColorRgb = accentRgbInt,
                             )
                         }
                     }
@@ -623,9 +637,13 @@ private fun LunarCycleCard(
     modifier: Modifier = Modifier,
 ) {
     val isDark = JewelTheme.isDark
+    val accentColor =
+        LocalAppGraph.current.mainAppState.accentColor
+            .collectAsState()
+            .value
+    val accent = accentColor.resolveColor(isDark)
     val shape = RoundedCornerShape(22.dp)
     val panelBackground = JewelTheme.globalColors.panelBackground
-    val accent = JewelTheme.globalColors.text.info
     val background =
         if (isDark) {
             Brush.verticalGradient(
@@ -768,7 +786,11 @@ private fun MoonIllustration(
     modifier: Modifier = Modifier,
 ) {
     val panelBackground = JewelTheme.globalColors.panelBackground
-    val accent = JewelTheme.globalColors.text.info
+    val accentColor =
+        LocalAppGraph.current.mainAppState.accentColor
+            .collectAsState()
+            .value
+    val accent = accentColor.resolveColor(isDark)
     val glowGradient =
         if (isDark) {
             Brush.radialGradient(
@@ -889,7 +911,11 @@ private fun IlluminationBar(
             JewelTheme.globalColors.borders.normal
                 .copy(alpha = 0.45f)
         }
-    val accent = JewelTheme.globalColors.text.info
+    val accentColor =
+        LocalAppGraph.current.mainAppState.accentColor
+            .collectAsState()
+            .value
+    val accent = accentColor.resolveColor(isDark)
     val fillGradient =
         if (isDark) {
             Brush.horizontalGradient(
@@ -933,6 +959,11 @@ private fun MoonEventCard(
     modifier: Modifier = Modifier,
 ) {
     val isDark = JewelTheme.isDark
+    val accentColor =
+        LocalAppGraph.current.mainAppState.accentColor
+            .collectAsState()
+            .value
+    val accent = accentColor.resolveColor(isDark)
     val shape = RoundedCornerShape(16.dp)
     val panelBackground = JewelTheme.globalColors.panelBackground
     val background =
@@ -947,7 +978,7 @@ private fun MoonEventCard(
             Brush.verticalGradient(
                 listOf(
                     panelBackground.blendTowards(Color.White, 0.10f),
-                    panelBackground.blendTowards(JewelTheme.globalColors.text.info, 0.05f),
+                    panelBackground.blendTowards(accent, 0.05f),
                 ),
             )
         }
@@ -996,7 +1027,11 @@ private fun NextFullMoonBar(
 ) {
     val shape = RoundedCornerShape(14.dp)
     val panelBackground = JewelTheme.globalColors.panelBackground
-    val accent = JewelTheme.globalColors.text.info
+    val accentColor =
+        LocalAppGraph.current.mainAppState.accentColor
+            .collectAsState()
+            .value
+    val accent = accentColor.resolveColor(isDark)
     val background =
         if (isDark) {
             Brush.horizontalGradient(
@@ -1063,7 +1098,11 @@ private fun MoonPhaseIcon(
     modifier: Modifier = Modifier,
 ) {
     val panelBackground = JewelTheme.globalColors.panelBackground
-    val accent = JewelTheme.globalColors.text.info
+    val accentColor =
+        LocalAppGraph.current.mainAppState.accentColor
+            .collectAsState()
+            .value
+    val accent = accentColor.resolveColor(isDark)
     val gradient =
         if (isDark) {
             Brush.radialGradient(
@@ -1269,6 +1308,11 @@ private fun DayMomentCard(
     onClick: (() -> Unit)? = null,
 ) {
     val isDark = JewelTheme.isDark
+    val accentColor =
+        LocalAppGraph.current.mainAppState.accentColor
+            .collectAsState()
+            .value
+    val accent = accentColor.resolveColor(isDark)
     val shape = RoundedCornerShape(18.dp)
     val panelBackground = JewelTheme.globalColors.panelBackground
     val background =
@@ -1283,7 +1327,7 @@ private fun DayMomentCard(
             Brush.verticalGradient(
                 listOf(
                     panelBackground.blendTowards(Color.White, 0.10f),
-                    panelBackground.blendTowards(JewelTheme.globalColors.text.info, 0.05f),
+                    panelBackground.blendTowards(accent, 0.05f),
                 ),
             )
         }
@@ -1532,6 +1576,11 @@ private fun DualTimeCardContent(
     compactMode: Boolean = false,
 ) {
     val isDark = JewelTheme.isDark
+    val accentColor =
+        LocalAppGraph.current.mainAppState.accentColor
+            .collectAsState()
+            .value
+    val accent = accentColor.resolveColor(isDark)
     val shape = RoundedCornerShape(18.dp)
     val panelBackground = JewelTheme.globalColors.panelBackground
     val background =
@@ -1546,7 +1595,7 @@ private fun DualTimeCardContent(
             Brush.verticalGradient(
                 listOf(
                     panelBackground.blendTowards(Color.White, 0.10f),
-                    panelBackground.blendTowards(JewelTheme.globalColors.text.info, 0.05f),
+                    panelBackground.blendTowards(accent, 0.05f),
                 ),
             )
         }
@@ -1559,8 +1608,8 @@ private fun DualTimeCardContent(
     val labelColor =
         JewelTheme.globalColors.text.normal
             .copy(alpha = 0.78f)
-    val accentStart = Color(0xFF9AE7E7)
-    val accentEnd = Color(0xFFC7F5F0)
+    val accentStart = accent.blendTowards(Color.White, 0.35f)
+    val accentEnd = accent.blendTowards(Color.White, 0.55f)
     val resolvedBackground = backgroundOverride ?: background
     val resolvedBorderColor = borderColorOverride ?: borderColor
     val resolvedAccentStart = accentStartOverride ?: accentStart
@@ -1870,29 +1919,34 @@ private fun ShabbatDualTimeCard(
     compactMode: Boolean = false,
 ) {
     val isDark = JewelTheme.isDark
+    val accentColor =
+        LocalAppGraph.current.mainAppState.accentColor
+            .collectAsState()
+            .value
+    val accent = accentColor.resolveColor(isDark)
     val panelBackground = JewelTheme.globalColors.panelBackground
     val premiumStart =
         if (isDark) {
-            panelBackground.blendTowards(Color(0xFF2B1F06), 0.7f)
+            panelBackground.blendTowards(accent.copy(alpha = 0.8f), 0.65f)
         } else {
-            panelBackground.blendTowards(Color(0xFFFFF4D0), 0.92f)
+            panelBackground.blendTowards(Color.White, 0.92f)
         }
     val premiumMid =
         if (isDark) {
-            panelBackground.blendTowards(Color(0xFF4A3309), 0.6f)
+            panelBackground.blendTowards(accent, 0.55f)
         } else {
-            panelBackground.blendTowards(Color(0xFFFFE3A8), 0.86f)
+            panelBackground.blendTowards(Color.White, 0.86f)
         }
     val premiumEnd =
         if (isDark) {
-            panelBackground.blendTowards(Color(0xFF7A5414), 0.5f)
+            panelBackground.blendTowards(accent.copy(alpha = 0.6f), 0.45f)
         } else {
-            panelBackground.blendTowards(Color(0xFFFFD187), 0.8f)
+            panelBackground.blendTowards(Color.White, 0.8f)
         }
     val background = Brush.verticalGradient(listOf(premiumStart, premiumMid, premiumEnd))
-    val borderColor = if (isDark) Color(0xFFB78A2E) else Color(0xFFE0B65C)
-    val accentStart = if (isDark) Color(0xFFF4D37D) else Color(0xFFC58A0E)
-    val accentEnd = if (isDark) Color(0xFFFFE7B0) else Color(0xFFFFD489)
+    val borderColor = accent
+    val accentStart = accent.blendTowards(Color.White, 0.35f)
+    val accentEnd = accent.blendTowards(Color.White, 0.55f)
     val sheen =
         if (isDark) {
             Brush.horizontalGradient(
@@ -1981,9 +2035,13 @@ private fun CelestialWidgetCard(
     content: @Composable BoxScope.() -> Unit,
 ) {
     val isDark = JewelTheme.isDark
+    val accentColor =
+        LocalAppGraph.current.mainAppState.accentColor
+            .collectAsState()
+            .value
+    val accent = accentColor.resolveColor(isDark)
     val shape = RoundedCornerShape(22.dp)
     val panelBackground = JewelTheme.globalColors.panelBackground
-    val accent = JewelTheme.globalColors.text.info
     val background =
         if (backgroundColor == null) {
             if (isDark) {

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeCelestialWidgets.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeCelestialWidgets.kt
@@ -234,18 +234,20 @@ private sealed class ZmanimGridItem {
 }
 
 @Composable
+private fun rememberAccentColor(isDark: Boolean): Color {
+    val accentColor by LocalAppGraph.current.mainAppState.accentColor
+        .collectAsState()
+    return accentColor.resolveColor(isDark)
+}
+
+@Composable
 fun HomeCelestialWidgets(
     locationState: HomeCelestialWidgetsState,
     modifier: Modifier = Modifier,
     userCommunityCode: String? = null,
 ) {
     val isDark = JewelTheme.isDark
-    val accentColor =
-        LocalAppGraph.current.mainAppState.accentColor
-            .collectAsState()
-            .value
-    val accent = accentColor.resolveColor(isDark)
-    // Convert accent color to 0x00RRGGBB for the pixel-level orbit renderer
+    val accent = rememberAccentColor(isDark)
     val accentRgbInt =
         ((accent.red * 255).toInt() shl 16) or
             ((accent.green * 255).toInt() shl 8) or
@@ -637,11 +639,7 @@ private fun LunarCycleCard(
     modifier: Modifier = Modifier,
 ) {
     val isDark = JewelTheme.isDark
-    val accentColor =
-        LocalAppGraph.current.mainAppState.accentColor
-            .collectAsState()
-            .value
-    val accent = accentColor.resolveColor(isDark)
+    val accent = rememberAccentColor(isDark)
     val shape = RoundedCornerShape(22.dp)
     val panelBackground = JewelTheme.globalColors.panelBackground
     val background =
@@ -786,11 +784,7 @@ private fun MoonIllustration(
     modifier: Modifier = Modifier,
 ) {
     val panelBackground = JewelTheme.globalColors.panelBackground
-    val accentColor =
-        LocalAppGraph.current.mainAppState.accentColor
-            .collectAsState()
-            .value
-    val accent = accentColor.resolveColor(isDark)
+    val accent = rememberAccentColor(isDark)
     val glowGradient =
         if (isDark) {
             Brush.radialGradient(
@@ -911,11 +905,7 @@ private fun IlluminationBar(
             JewelTheme.globalColors.borders.normal
                 .copy(alpha = 0.45f)
         }
-    val accentColor =
-        LocalAppGraph.current.mainAppState.accentColor
-            .collectAsState()
-            .value
-    val accent = accentColor.resolveColor(isDark)
+    val accent = rememberAccentColor(isDark)
     val fillGradient =
         if (isDark) {
             Brush.horizontalGradient(
@@ -959,11 +949,7 @@ private fun MoonEventCard(
     modifier: Modifier = Modifier,
 ) {
     val isDark = JewelTheme.isDark
-    val accentColor =
-        LocalAppGraph.current.mainAppState.accentColor
-            .collectAsState()
-            .value
-    val accent = accentColor.resolveColor(isDark)
+    val accent = rememberAccentColor(isDark)
     val shape = RoundedCornerShape(16.dp)
     val panelBackground = JewelTheme.globalColors.panelBackground
     val background =
@@ -1027,11 +1013,7 @@ private fun NextFullMoonBar(
 ) {
     val shape = RoundedCornerShape(14.dp)
     val panelBackground = JewelTheme.globalColors.panelBackground
-    val accentColor =
-        LocalAppGraph.current.mainAppState.accentColor
-            .collectAsState()
-            .value
-    val accent = accentColor.resolveColor(isDark)
+    val accent = rememberAccentColor(isDark)
     val background =
         if (isDark) {
             Brush.horizontalGradient(
@@ -1098,11 +1080,7 @@ private fun MoonPhaseIcon(
     modifier: Modifier = Modifier,
 ) {
     val panelBackground = JewelTheme.globalColors.panelBackground
-    val accentColor =
-        LocalAppGraph.current.mainAppState.accentColor
-            .collectAsState()
-            .value
-    val accent = accentColor.resolveColor(isDark)
+    val accent = rememberAccentColor(isDark)
     val gradient =
         if (isDark) {
             Brush.radialGradient(
@@ -1308,11 +1286,7 @@ private fun DayMomentCard(
     onClick: (() -> Unit)? = null,
 ) {
     val isDark = JewelTheme.isDark
-    val accentColor =
-        LocalAppGraph.current.mainAppState.accentColor
-            .collectAsState()
-            .value
-    val accent = accentColor.resolveColor(isDark)
+    val accent = rememberAccentColor(isDark)
     val shape = RoundedCornerShape(18.dp)
     val panelBackground = JewelTheme.globalColors.panelBackground
     val background =
@@ -1576,11 +1550,7 @@ private fun DualTimeCardContent(
     compactMode: Boolean = false,
 ) {
     val isDark = JewelTheme.isDark
-    val accentColor =
-        LocalAppGraph.current.mainAppState.accentColor
-            .collectAsState()
-            .value
-    val accent = accentColor.resolveColor(isDark)
+    val accent = rememberAccentColor(isDark)
     val shape = RoundedCornerShape(18.dp)
     val panelBackground = JewelTheme.globalColors.panelBackground
     val background =
@@ -1919,11 +1889,7 @@ private fun ShabbatDualTimeCard(
     compactMode: Boolean = false,
 ) {
     val isDark = JewelTheme.isDark
-    val accentColor =
-        LocalAppGraph.current.mainAppState.accentColor
-            .collectAsState()
-            .value
-    val accent = accentColor.resolveColor(isDark)
+    val accent = rememberAccentColor(isDark)
     val panelBackground = JewelTheme.globalColors.panelBackground
     val premiumStart =
         if (isDark) {
@@ -2035,11 +2001,7 @@ private fun CelestialWidgetCard(
     content: @Composable BoxScope.() -> Unit,
 ) {
     val isDark = JewelTheme.isDark
-    val accentColor =
-        LocalAppGraph.current.mainAppState.accentColor
-            .collectAsState()
-            .value
-    val accent = accentColor.resolveColor(isDark)
+    val accent = rememberAccentColor(isDark)
     val shape = RoundedCornerShape(22.dp)
     val panelBackground = JewelTheme.globalColors.panelBackground
     val background =

--- a/earthwidget/src/commonMain/kotlin/io/github/kdroidfilter/seforimapp/earthwidget/EarthTextureSphereRenderer.kt
+++ b/earthwidget/src/commonMain/kotlin/io/github/kdroidfilter/seforimapp/earthwidget/EarthTextureSphereRenderer.kt
@@ -585,6 +585,7 @@ internal suspend fun renderEarthWithMoonArgb(
     starfieldCache: StarfieldCache? = null,
     kiddushLevanaStartDegrees: Float? = null,
     kiddushLevanaEndDegrees: Float? = null,
+    kiddushLevanaColorRgb: Int = KIDDUSH_LEVANA_COLOR_RGB,
 ): IntArray {
     val outputSize = outputSizePx * outputSizePx
     val out =
@@ -669,6 +670,7 @@ internal suspend fun renderEarthWithMoonArgb(
                 cameraZ = geometry.cameraZ,
                 kiddushLevanaStartDegrees = kiddushLevanaStartDegrees,
                 kiddushLevanaEndDegrees = kiddushLevanaEndDegrees,
+                kiddushLevanaColorRgb = kiddushLevanaColorRgb,
             )
         }
 
@@ -1153,6 +1155,7 @@ private fun drawOrbitPath(
     cameraZ: Float,
     kiddushLevanaStartDegrees: Float? = null,
     kiddushLevanaEndDegrees: Float? = null,
+    kiddushLevanaColorRgb: Int = KIDDUSH_LEVANA_COLOR_RGB,
 ) {
     if (orbitRadius <= 0f) return
 
@@ -1197,7 +1200,7 @@ private fun drawOrbitPath(
                 if (isKiddushLevana) {
                     Triple(
                         if (avgZ >= 0f) KIDDUSH_LEVANA_ALPHA_FRONT else KIDDUSH_LEVANA_ALPHA_BACK,
-                        KIDDUSH_LEVANA_COLOR_RGB,
+                        kiddushLevanaColorRgb,
                         KIDDUSH_LEVANA_GLOW_INTENSITY,
                     )
                 } else {

--- a/earthwidget/src/commonMain/kotlin/io/github/kdroidfilter/seforimapp/earthwidget/EarthWidgetRenderer.kt
+++ b/earthwidget/src/commonMain/kotlin/io/github/kdroidfilter/seforimapp/earthwidget/EarthWidgetRenderer.kt
@@ -35,6 +35,7 @@ internal data class EarthRenderState(
     val earthSizeFraction: Float,
     val kiddushLevanaStartDegrees: Float? = null,
     val kiddushLevanaEndDegrees: Float? = null,
+    val kiddushLevanaColorRgb: Int = KIDDUSH_LEVANA_COLOR_RGB,
 )
 
 /**
@@ -116,6 +117,7 @@ internal class EarthWidgetRenderer(
                         starfieldCache = starfieldCache,
                         kiddushLevanaStartDegrees = state.kiddushLevanaStartDegrees,
                         kiddushLevanaEndDegrees = state.kiddushLevanaEndDegrees,
+                        kiddushLevanaColorRgb = state.kiddushLevanaColorRgb,
                     )
 
                 // Convert to ImageBitmap (copies the data)

--- a/earthwidget/src/commonMain/kotlin/io/github/kdroidfilter/seforimapp/earthwidget/EarthWidgetView.kt
+++ b/earthwidget/src/commonMain/kotlin/io/github/kdroidfilter/seforimapp/earthwidget/EarthWidgetView.kt
@@ -152,6 +152,7 @@ fun EarthWidgetScene(
     moonFromMarkerSunElevationDegrees: Float? = null,
     kiddushLevanaStartDegrees: Float? = null,
     kiddushLevanaEndDegrees: Float? = null,
+    kiddushLevanaColorRgb: Int = KIDDUSH_LEVANA_COLOR_RGB,
 ) {
     // Earth rotation and light can be instant (during drag) or animated (location change)
     val animatedEarthRotation =
@@ -246,6 +247,7 @@ fun EarthWidgetScene(
             earthSizeFraction = earthSizeFraction,
             kiddushLevanaStartDegrees = kiddushLevanaStartDegrees,
             kiddushLevanaEndDegrees = kiddushLevanaEndDegrees,
+            kiddushLevanaColorRgb = kiddushLevanaColorRgb,
         )
 
     val renderedScene =

--- a/earthwidget/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/earthwidget/EarthWidgetZmanimView.kt
+++ b/earthwidget/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/earthwidget/EarthWidgetZmanimView.kt
@@ -204,6 +204,7 @@ fun EarthWidgetZmanimView(
     kiddushLevanaEarliestOpinion: KiddushLevanaEarliestOpinion = KiddushLevanaEarliestOpinion.DAYS_3,
     kiddushLevanaLatestOpinion: KiddushLevanaLatestOpinion = KiddushLevanaLatestOpinion.BETWEEN_MOLDOS,
     initialShowKiddushLevana: Boolean = true,
+    kiddushLevanaColorRgb: Int = KIDDUSH_LEVANA_COLOR_RGB,
 ) {
     // Location state (defaults to Jerusalem, overridden by locationOverride)
     var markerLatitudeDegrees by remember { mutableFloatStateOf(DEFAULT_MARKER_LAT.toFloat()) }
@@ -507,6 +508,7 @@ fun EarthWidgetZmanimView(
             earthSizeFraction = earthSizeFraction,
             isDraggingEarth = isDraggingEarth,
             kiddushLevanaData = kiddushLevanaData,
+            kiddushLevanaColorRgb = kiddushLevanaColorRgb,
         )
         if (showKiddushLevanaLegend) {
             KiddushLevanaLegend(
@@ -673,6 +675,7 @@ private fun EarthSceneContent(
     isDraggingEarth: Boolean,
     modifier: Modifier = Modifier,
     kiddushLevanaData: KiddushLevanaData? = null,
+    kiddushLevanaColorRgb: Int = KIDDUSH_LEVANA_COLOR_RGB,
 ) {
     val density = LocalDensity.current
     val degreesPerPx =
@@ -726,6 +729,7 @@ private fun EarthSceneContent(
             animateEarthRotation = !isDraggingEarth, // Instant rotation during drag
             kiddushLevanaStartDegrees = kiddushLevanaData?.startDegrees,
             kiddushLevanaEndDegrees = kiddushLevanaData?.endDegrees,
+            kiddushLevanaColorRgb = kiddushLevanaColorRgb,
         )
     }
 }

--- a/earthwidget/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/earthwidget/EarthWidgetZmanimView.kt
+++ b/earthwidget/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/earthwidget/EarthWidgetZmanimView.kt
@@ -516,6 +516,7 @@ fun EarthWidgetZmanimView(
                     Modifier
                         .align(Alignment.BottomStart)
                         .padding(start = 8.dp, bottom = 8.dp),
+                legendColorRgb = kiddushLevanaColorRgb,
             )
         }
         if (earthRotationOffset != 0f || isDateTimeModified) {
@@ -797,12 +798,16 @@ private fun ResetDateTimeButton(
 }
 
 @Composable
-private fun KiddushLevanaLegend(modifier: Modifier = Modifier) {
+private fun KiddushLevanaLegend(
+    modifier: Modifier = Modifier,
+    legendColorRgb: Int = KIDDUSH_LEVANA_COLOR_RGB,
+) {
     IntUiTheme(isDark = true) {
         val shape = RoundedCornerShape(50)
         val background = JewelTheme.globalColors.panelBackground.copy(alpha = 0.86f)
         val borderColor = JewelTheme.globalColors.borders.disabled
         val textColor = JewelTheme.globalColors.text.normal
+        val legendColor = Color(0xFF000000.toLong() + legendColorRgb)
 
         Row(
             modifier =
@@ -818,7 +823,7 @@ private fun KiddushLevanaLegend(modifier: Modifier = Modifier) {
                 modifier =
                     Modifier
                         .size(10.dp)
-                        .background(KIDDUSH_LEVANA_LEGEND_COLOR, CircleShape)
+                        .background(legendColor, CircleShape)
                         .border(1.dp, borderColor, CircleShape),
             )
             Text(


### PR DESCRIPTION
## Summary

- Replace hardcoded `JewelTheme.globalColors.text.info` in `HomeCelestialWidgets.kt` with user accent color across all zmanim card composables
- Derive accent gradient dots in `DualTimeCardContent` from accent instead of hardcoded cyan
- Thread `kiddushLevanaColorRgb: Int` through earthwidget rendering chain so the Birkat Halevana orbit arc uses the accent color
- Update `ShabbatDualTimeCard` background gradient and border to use accent-derived colors

## Modules touched

- `SeforimApp` — HomeCelestialWidgets.kt (card composables, accent color collection)
- `earthwidget` — EarthRenderState, EarthTextureSphereRenderer, EarthWidgetRenderer, EarthWidgetView, EarthWidgetZmanimView

## Test plan

- [ ] Run desktop app: `./gradlew :SeforimApp:run`
- [ ] Verify zmanim cards (zmanim/times, Birkat Halevana, Shabbat) use the selected accent color
- [ ] ktlint passes: `./gradlew :SeforimApp:ktlintCheck`
- [ ] JVM tests pass: `./gradlew :SeforimApp:jvmTest`