### PR TITLE
feat(#352): cross-section text selection in Mefarshim and Mekorot

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/components/SelectionWorkarounds.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/components/SelectionWorkarounds.kt
@@ -1,0 +1,26 @@
+package io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components
+
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.isPrimaryPressed
+import androidx.compose.ui.input.pointer.isShiftPressed
+import androidx.compose.ui.input.pointer.pointerInput
+
+/**
+ * Workaround for a Compose crash when extending selection with Shift+primary across multiple
+ * selectables in a virtualized list. Consumes Shift+primary presses during the Initial pass so
+ * the enclosing SelectionContainer never runs the extend-selection path. Normal drag selection
+ * and regular clicks are left untouched.
+ */
+fun Modifier.consumeShiftPrimaryPress(): Modifier =
+    this.pointerInput(Unit) {
+        awaitEachGesture {
+            val event = awaitPointerEvent(PointerEventPass.Initial)
+            val isShiftPrimaryPress =
+                event.buttons.isPrimaryPressed && event.keyboardModifiers.isShiftPressed
+            if (isShiftPrimaryPress) {
+                event.changes.forEach { it.consume() }
+            }
+        }
+    }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/components/SelectionWorkarounds.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/components/SelectionWorkarounds.kt
@@ -1,6 +1,9 @@
 package io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components
 
 import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.isPrimaryPressed
@@ -8,19 +11,34 @@ import androidx.compose.ui.input.pointer.isShiftPressed
 import androidx.compose.ui.input.pointer.pointerInput
 
 /**
- * Workaround for a Compose crash when extending selection with Shift+primary across multiple
- * selectables in a virtualized list. Consumes Shift+primary presses during the Initial pass so
- * the enclosing SelectionContainer never runs the extend-selection path. Normal drag selection
- * and regular clicks are left untouched.
+ * Drop-in replacement for [SelectionContainer] that works around a Compose crash when extending
+ * selection with Shift+primary across multiple selectables in a virtualized list
+ * (see Zayit issue #48). Shift+primary presses are consumed during the Initial pointer pass so
+ * the inner [SelectionContainer] never runs the extend-selection path. Normal drag selection
+ * and regular clicks are untouched.
+ *
+ * When upstream Compose fixes the bug, delete this file and replace call sites with
+ * [SelectionContainer].
  */
-fun Modifier.consumeShiftPrimaryPress(): Modifier =
-    this.pointerInput(Unit) {
-        awaitEachGesture {
-            val event = awaitPointerEvent(PointerEventPass.Initial)
-            val isShiftPrimaryPress =
-                event.buttons.isPrimaryPressed && event.keyboardModifiers.isShiftPressed
-            if (isShiftPrimaryPress) {
-                event.changes.forEach { it.consume() }
-            }
-        }
+@Composable
+fun SafeSelectionContainer(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier =
+            modifier
+                .pointerInput(Unit) {
+                    awaitEachGesture {
+                        val event = awaitPointerEvent(PointerEventPass.Initial)
+                        val isShiftPrimaryPress =
+                            event.buttons.isPrimaryPressed && event.keyboardModifiers.isShiftPressed
+                        if (isShiftPrimaryPress) {
+                            event.changes.forEach { it.consume() }
+                        }
+                    }
+                },
+    ) {
+        SelectionContainer(content = content)
     }
+}

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BookContentView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BookContentView.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.*
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.ui.Alignment
@@ -35,7 +34,6 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.isCtrlPressed
 import androidx.compose.ui.input.pointer.isMetaPressed
 import androidx.compose.ui.input.pointer.isPrimaryPressed
-import androidx.compose.ui.input.pointer.isShiftPressed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
@@ -56,6 +54,7 @@ import io.github.kdroidfilter.seforimapp.core.presentation.typography.FontCatalo
 import io.github.kdroidfilter.seforimapp.core.settings.AppSettings
 import io.github.kdroidfilter.seforimapp.features.bookcontent.BookContentEvent
 import io.github.kdroidfilter.seforimapp.features.bookcontent.state.LineConnectionsSnapshot
+import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.SafeSelectionContainer
 import io.github.kdroidfilter.seforimapp.framework.di.LocalAppGraph
 import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import io.github.kdroidfilter.seforimapp.logger.debugln
@@ -572,243 +571,227 @@ fun BookContentView(
         }
     }
 
-    // Workaround for Compose selection crash when extending selection with Shift+Click across
-    // multiple selectables in a virtualized list. We intercept Shift+primary mouse presses at
-    // the container level to avoid the extend-selection path, while preserving normal drag
-    // selection and regular clicks.
-    Box(
+    SafeSelectionContainer(
         modifier =
             modifier
                 .fillMaxSize()
                 .graphicsLayer { alpha = contentAlpha } // Hide until positioned to prevent glitch
                 .focusRequester(focusRequester)
                 .onPreviewKeyEvent(previewKeyHandler)
-                .focusable()
-                .pointerInput(Unit) {
-                    awaitEachGesture {
-                        val event = awaitPointerEvent(PointerEventPass.Initial)
-                        val isShiftPrimaryPress = event.buttons.isPrimaryPressed && event.keyboardModifiers.isShiftPressed
-                        if (isShiftPrimaryPress) {
-                            // Consume to prevent SelectionContainer from handling extend-selection
-                            event.changes.forEach { it.consume() }
-                        }
-                    }
-                },
+                .focusable(),
     ) {
-        SelectionContainer {
-            Box(modifier = Modifier.fillMaxSize().padding(bottom = 8.dp)) {
-                // Content list. Avoid a single SelectionContainer around the entire
-                // paged list to prevent cross-item selection spanning unloaded pages,
-                // which can crash when paging composes/uncomposes items.
-                LazyColumn(
-                    state = listState,
-                    modifier = Modifier.fillMaxSize().padding(end = 16.dp),
-                ) {
-                    items(
-                        count = lazyPagingItems.itemCount,
-                        key = lazyPagingItems.itemKey { it.id },
-                        contentType = { "line" }, // Optimization: specify content type
-                    ) { index ->
-                        val line = lazyPagingItems[index]
+        Box(modifier = Modifier.fillMaxSize().padding(bottom = 8.dp)) {
+            // Content list. Avoid a single SelectionContainer around the entire
+            // paged list to prevent cross-item selection spanning unloaded pages,
+            // which can crash when paging composes/uncomposes items.
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize().padding(end = 16.dp),
+            ) {
+                items(
+                    count = lazyPagingItems.itemCount,
+                    key = lazyPagingItems.itemKey { it.id },
+                    contentType = { "line" }, // Optimization: specify content type
+                ) { index ->
+                    val line = lazyPagingItems[index]
 
-                        if (line != null) {
-                            val altHeadings = altHeadingsByLineId[line.id]
-                            val isCurrentSelected = line.id in selectedLineIds
-                            val useThickBar = shouldUseThickBar(line.id, primarySelectedLineId, isTocEntrySelection)
-                            val nextLineId = if (index < lazyPagingItems.itemCount - 1) lazyPagingItems.peek(index + 1)?.id else null
-                            val nextUseThickBar = shouldUseThickBar(nextLineId ?: -1, primarySelectedLineId, isTocEntrySelection)
-                            val isNextSelected =
-                                shouldExtendToNext(isCurrentSelected, nextLineId, selectedLineIds, useThickBar, nextUseThickBar)
+                    if (line != null) {
+                        val altHeadings = altHeadingsByLineId[line.id]
+                        val isCurrentSelected = line.id in selectedLineIds
+                        val useThickBar = shouldUseThickBar(line.id, primarySelectedLineId, isTocEntrySelection)
+                        val nextLineId = if (index < lazyPagingItems.itemCount - 1) lazyPagingItems.peek(index + 1)?.id else null
+                        val nextUseThickBar = shouldUseThickBar(nextLineId ?: -1, primarySelectedLineId, isTocEntrySelection)
+                        val isNextSelected =
+                            shouldExtendToNext(isCurrentSelected, nextLineId, selectedLineIds, useThickBar, nextUseThickBar)
 
-                            val prevLineId =
-                                if (index > 0) lazyPagingItems.peek(index - 1)?.id else null
-                            val isPrevSelected =
-                                prevLineId != null && prevLineId in selectedLineIds
-                            // Alt headings go inside the selection bar only when
-                            // the previous line is also selected (consecutive selection).
-                            val altHeadingsInsideBar =
-                                shouldPlaceAltHeadingsInsideBar(isCurrentSelected, isPrevSelected, altHeadings.isNotEmpty())
+                        val prevLineId =
+                            if (index > 0) lazyPagingItems.peek(index - 1)?.id else null
+                        val isPrevSelected =
+                            prevLineId != null && prevLineId in selectedLineIds
+                        // Alt headings go inside the selection bar only when
+                        // the previous line is also selected (consecutive selection).
+                        val altHeadingsInsideBar =
+                            shouldPlaceAltHeadingsInsideBar(isCurrentSelected, isPrevSelected, altHeadings.isNotEmpty())
 
-                            val borderColor =
-                                if (isCurrentSelected) {
-                                    if (useThickBar) {
-                                        JewelTheme.globalColors.outlines.focused
-                                    } else {
-                                        JewelTheme.globalColors.borders.normal
-                                    }
+                        val borderColor =
+                            if (isCurrentSelected) {
+                                if (useThickBar) {
+                                    JewelTheme.globalColors.outlines.focused
                                 } else {
-                                    Color.Transparent
+                                    JewelTheme.globalColors.borders.normal
                                 }
-
-                            // Alt headings outside the selection bar when line is
-                            // selected alone or is the first in a consecutive selection
-                            if (altHeadings.isNotEmpty() && !altHeadingsInsideBar) {
-                                Column(
-                                    modifier = Modifier.padding(horizontal = 8.dp).padding(start = 12.dp),
-                                ) {
-                                    altHeadings.forEach { entry ->
-                                        AltHeadingItem(
-                                            entryId = entry.id,
-                                            level = entry.level,
-                                            text = entry.text,
-                                            onClick = { onLineSelect(line, false) },
-                                        )
-                                    }
-                                }
+                            } else {
+                                Color.Transparent
                             }
 
-                            Row(
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth()
-                                        .padding(horizontal = 8.dp)
-                                        .height(IntrinsicSize.Min),
+                        // Alt headings outside the selection bar when line is
+                        // selected alone or is the first in a consecutive selection
+                        if (altHeadings.isNotEmpty() && !altHeadingsInsideBar) {
+                            Column(
+                                modifier = Modifier.padding(horizontal = 8.dp).padding(start = 12.dp),
                             ) {
-                                SelectionBar(
-                                    isSelected = isCurrentSelected,
-                                    isNextSelected = isNextSelected,
-                                    color = borderColor,
-                                    isPrimary = useThickBar,
-                                )
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Column(
-                                    modifier = Modifier.weight(1f),
-                                ) {
-                                    if (altHeadingsInsideBar) {
-                                        Column {
-                                            altHeadings.forEach { entry ->
-                                                AltHeadingItem(
-                                                    entryId = entry.id,
-                                                    level = entry.level,
-                                                    text = entry.text,
-                                                    onClick = { onLineSelect(line, false) },
-                                                )
-                                            }
+                                altHeadings.forEach { entry ->
+                                    AltHeadingItem(
+                                        entryId = entry.id,
+                                        level = entry.level,
+                                        text = entry.text,
+                                        onClick = { onLineSelect(line, false) },
+                                    )
+                                }
+                            }
+                        }
+
+                        Row(
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 8.dp)
+                                    .height(IntrinsicSize.Min),
+                        ) {
+                            SelectionBar(
+                                isSelected = isCurrentSelected,
+                                isNextSelected = isNextSelected,
+                                color = borderColor,
+                                isPrimary = useThickBar,
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Column(
+                                modifier = Modifier.weight(1f),
+                            ) {
+                                if (altHeadingsInsideBar) {
+                                    Column {
+                                        altHeadings.forEach { entry ->
+                                            AltHeadingItem(
+                                                entryId = entry.id,
+                                                level = entry.level,
+                                                text = entry.text,
+                                                onClick = { onLineSelect(line, false) },
+                                            )
                                         }
                                     }
-                                    Box(modifier = Modifier.padding(vertical = 8.dp)) {
-                                        LineItem(
-                                            lineId = line.id,
-                                            lineContent = line.content,
-                                            fontFamily = hebrewFontFamily,
-                                            onClick = { isModifier -> onLineSelect(line, isModifier) },
-                                            isSelected = isCurrentSelected,
-                                            isPrimary = useThickBar,
-                                            baseTextSize = textSize,
-                                            lineHeight = lineHeight,
-                                            boldScale = boldScaleForPlatform,
-                                            highlightQuery =
-                                                findState.text.toString().takeIf { showFind && !smartModeEnabled },
-                                            highlightTerms = smartHighlightTerms.takeIf { showFind && smartModeEnabled },
-                                            currentMatchStart =
-                                                if (showFind && currentMatchLineId == line.id) currentMatchStart else null,
-                                            annotatedCache = stableAnnotatedCache,
-                                            showDiacritics = showDiacritics,
-                                        )
-                                    }
+                                }
+                                Box(modifier = Modifier.padding(vertical = 8.dp)) {
+                                    LineItem(
+                                        lineId = line.id,
+                                        lineContent = line.content,
+                                        fontFamily = hebrewFontFamily,
+                                        onClick = { isModifier -> onLineSelect(line, isModifier) },
+                                        isSelected = isCurrentSelected,
+                                        isPrimary = useThickBar,
+                                        baseTextSize = textSize,
+                                        lineHeight = lineHeight,
+                                        boldScale = boldScaleForPlatform,
+                                        highlightQuery =
+                                            findState.text.toString().takeIf { showFind && !smartModeEnabled },
+                                        highlightTerms = smartHighlightTerms.takeIf { showFind && smartModeEnabled },
+                                        currentMatchStart =
+                                            if (showFind && currentMatchLineId == line.id) currentMatchStart else null,
+                                        annotatedCache = stableAnnotatedCache,
+                                        showDiacritics = showDiacritics,
+                                    )
                                 }
                             }
-                        } else {
-                            // Placeholder while loading
-                            LoadingPlaceholder()
                         }
+                    } else {
+                        // Placeholder while loading
+                        LoadingPlaceholder()
                     }
+                }
 
-                    // Show loading indicators
-                    lazyPagingItems.apply {
-                        when {
-                            // Avoid flicker: only show full loader on refresh if we have no items yet
-                            loadState.refresh is LoadState.Loading && itemCount == 0 -> {
-                                item(contentType = "loading") {
-                                    LoadingIndicator()
-                                }
+                // Show loading indicators
+                lazyPagingItems.apply {
+                    when {
+                        // Avoid flicker: only show full loader on refresh if we have no items yet
+                        loadState.refresh is LoadState.Loading && itemCount == 0 -> {
+                            item(contentType = "loading") {
+                                LoadingIndicator()
                             }
+                        }
 
-                            // Keep small loader for pagination append
-                            loadState.append is LoadState.Loading -> {
-                                item(contentType = "loading") {
-                                    LoadingIndicator(isSmall = true)
-                                }
+                        // Keep small loader for pagination append
+                        loadState.append is LoadState.Loading -> {
+                            item(contentType = "loading") {
+                                LoadingIndicator(isSmall = true)
                             }
+                        }
 
-                            loadState.refresh is LoadState.Error -> {
-                                val error = (loadState.refresh as LoadState.Error).error
-                                item(contentType = "error") {
-                                    ErrorIndicator(message = "Error: ${error.message}")
-                                }
+                        loadState.refresh is LoadState.Error -> {
+                            val error = (loadState.refresh as LoadState.Error).error
+                            item(contentType = "error") {
+                                ErrorIndicator(message = "Error: ${error.message}")
                             }
+                        }
 
-                            loadState.append is LoadState.Error -> {
-                                val error = (loadState.append as LoadState.Error).error
-                                item(contentType = "error") {
-                                    ErrorIndicator(message = "Error loading more: ${error.message}")
-                                }
+                        loadState.append is LoadState.Error -> {
+                            val error = (loadState.append as LoadState.Error).error
+                            item(contentType = "error") {
+                                ErrorIndicator(message = "Error loading more: ${error.message}")
                             }
                         }
                     }
                 }
             }
+        }
 
-            // Find-in-page bar overlay with result count badge (uniform style)
-            if (showFind) {
-                // Compute total matches across currently loaded snapshot (approximate)
-                val queryText = findState.text.toString()
-                val snapshotItems = lazyPagingItems.itemSnapshotList.items
-                val matchCount by produceState(0, queryText, snapshotItems) {
-                    value =
-                        if (queryText.length < 2) {
-                            0
-                        } else {
-                            kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
-                                var total = 0
-                                for (ln in snapshotItems) {
-                                    val text =
-                                        try {
-                                            buildAnnotatedFromHtml(ln.content, textSize).text
-                                        } catch (_: Throwable) {
-                                            ln.content
-                                        }
-                                    total += findAllMatchesOriginal(text, queryText).size
-                                }
-                                total
+        // Find-in-page bar overlay with result count badge (uniform style)
+        if (showFind) {
+            // Compute total matches across currently loaded snapshot (approximate)
+            val queryText = findState.text.toString()
+            val snapshotItems = lazyPagingItems.itemSnapshotList.items
+            val matchCount by produceState(0, queryText, snapshotItems) {
+                value =
+                    if (queryText.length < 2) {
+                        0
+                    } else {
+                        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
+                            var total = 0
+                            for (ln in snapshotItems) {
+                                val text =
+                                    try {
+                                        buildAnnotatedFromHtml(ln.content, textSize).text
+                                    } catch (_: Throwable) {
+                                        ln.content
+                                    }
+                                total += findAllMatchesOriginal(text, queryText).size
                             }
+                            total
                         }
+                    }
+            }
+            Row(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(12.dp)
+                        .zIndex(2f),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (queryText.length >= 2) {
+                    // Wrap badge in a small panel background to improve border contrast,
+                    // keeping the badge's own border color (disabled) identical to the tree.
+                    Box(
+                        modifier =
+                            Modifier
+                                .clip(RoundedCornerShape(8.dp))
+                                .background(JewelTheme.globalColors.panelBackground)
+                                .padding(2.dp),
+                    ) {
+                        CountBadge(count = matchCount)
+                    }
+                    Spacer(Modifier.width(8.dp))
                 }
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(12.dp)
-                            .zIndex(2f),
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    if (queryText.length >= 2) {
-                        // Wrap badge in a small panel background to improve border contrast,
-                        // keeping the badge's own border color (disabled) identical to the tree.
-                        Box(
-                            modifier =
-                                Modifier
-                                    .clip(RoundedCornerShape(8.dp))
-                                    .background(JewelTheme.globalColors.panelBackground)
-                                    .padding(2.dp),
-                        ) {
-                            CountBadge(count = matchCount)
-                        }
-                        Spacer(Modifier.width(8.dp))
-                    }
-                    FindInPageBar(
-                        state = findState,
-                        onEnterNext = { navigateToMatch(true, scope) },
-                        onEnterPrev = { navigateToMatch(false, scope) },
-                        onClose = { AppSettings.closeFindBar(tabId) },
-                        smartModeEnabled = smartModeEnabled,
-                        onToggleSmartMode = { AppSettings.toggleFindSmartMode(tabId) },
-                    )
-                    LaunchedEffect(findState.text, showFind) {
-                        val q = findState.text.toString()
-                        AppSettings.setFindQuery(tabId, if (q.length >= 2) q else "")
-                    }
+                FindInPageBar(
+                    state = findState,
+                    onEnterNext = { navigateToMatch(true, scope) },
+                    onEnterPrev = { navigateToMatch(false, scope) },
+                    onClose = { AppSettings.closeFindBar(tabId) },
+                    smartModeEnabled = smartModeEnabled,
+                    onToggleSmartMode = { AppSettings.toggleFindSmartMode(tabId) },
+                )
+                LaunchedEffect(findState.text, showFind) {
+                    val q = findState.text.toString()
+                    AppSettings.setFindQuery(tabId, if (q.length >= 2) q else "")
                 }
             }
         }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BookContentView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BookContentView.kt
@@ -581,9 +581,6 @@ fun BookContentView(
                 .focusable(),
     ) {
         Box(modifier = Modifier.fillMaxSize().padding(bottom = 8.dp)) {
-            // Content list. Avoid a single SelectionContainer around the entire
-            // paged list to prevent cross-item selection spanning unloaded pages,
-            // which can crash when paging composes/uncomposes items.
             LazyColumn(
                 state = listState,
                 modifier = Modifier.fillMaxSize().padding(end = 16.dp),

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
@@ -21,11 +21,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
-import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.isCtrlPressed
 import androidx.compose.ui.input.pointer.isMetaPressed
 import androidx.compose.ui.input.pointer.isPrimaryPressed
-import androidx.compose.ui.input.pointer.isShiftPressed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.AnnotatedString
@@ -52,6 +50,7 @@ import io.github.kdroidfilter.seforimapp.features.bookcontent.state.LineConnecti
 import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.EnhancedHorizontalSplitPane
 import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.PaneHeader
 import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.asStable
+import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.consumeShiftPrimaryPress
 import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import io.github.kdroidfilter.seforimapp.icons.LayoutSidebarRight
 import io.github.kdroidfilter.seforimapp.icons.LayoutSidebarRightOff
@@ -565,26 +564,30 @@ private fun MultiLineCommentaryListView(
             .collect { (i, o) -> currentOnScroll(i, o) }
     }
 
-    VerticallyScrollableContainer(
-        scrollState = listState as ScrollableState,
-        scrollbarModifier = Modifier.fillMaxHeight(),
-    ) {
-        LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
-            items(
-                count = lazyPagingItems.itemCount,
-                key = { index -> lazyPagingItems[index]?.link?.id ?: index },
-            ) { index ->
-                lazyPagingItems[index]?.let { commentary ->
-                    CommentaryItem(
-                        linkId = commentary.link.id,
-                        targetText = commentary.targetText,
-                        textSizes = config.textSizes,
-                        fontFamily = config.fontFamily,
-                        boldScale = config.boldScale,
-                        highlightQuery = highlightQuery,
-                        showDiacritics = config.showDiacritics,
-                        onClick = { config.onCommentClick(commentary) },
-                    )
+    Box(modifier = Modifier.fillMaxSize().consumeShiftPrimaryPress()) {
+        SelectionContainer {
+            VerticallyScrollableContainer(
+                scrollState = listState as ScrollableState,
+                scrollbarModifier = Modifier.fillMaxHeight(),
+            ) {
+                LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+                    items(
+                        count = lazyPagingItems.itemCount,
+                        key = { index -> lazyPagingItems[index]?.link?.id ?: index },
+                    ) { index ->
+                        lazyPagingItems[index]?.let { commentary ->
+                            CommentaryItem(
+                                linkId = commentary.link.id,
+                                targetText = commentary.targetText,
+                                textSizes = config.textSizes,
+                                fontFamily = config.fontFamily,
+                                boldScale = config.boldScale,
+                                highlightQuery = highlightQuery,
+                                showDiacritics = config.showDiacritics,
+                                onClick = { config.onCommentClick(commentary) },
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -886,52 +889,45 @@ private fun CommentaryListView(
             }
     }
 
-    LazyColumn(
-        state = listState,
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .pointerInput(Unit) {
-                    awaitEachGesture {
-                        val event = awaitPointerEvent(PointerEventPass.Initial)
-                        val isShiftPrimaryPress = event.buttons.isPrimaryPressed && event.keyboardModifiers.isShiftPressed
-                        if (isShiftPrimaryPress) {
-                            event.changes.forEach { it.consume() }
+    Box(modifier = Modifier.fillMaxSize().consumeShiftPrimaryPress()) {
+        SelectionContainer {
+            LazyColumn(
+                state = listState,
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                items(
+                    count = lazyPagingItems.itemCount,
+                    key = { index -> lazyPagingItems[index]?.link?.id ?: index }, // Clé stable
+                ) { index ->
+                    lazyPagingItems[index]?.let { commentary ->
+                        CommentaryItem(
+                            linkId = commentary.link.id,
+                            targetText = commentary.targetText,
+                            textSizes = config.textSizes,
+                            fontFamily = config.fontFamily,
+                            boldScale = config.boldScale,
+                            highlightQuery = highlightQuery,
+                            showDiacritics = config.showDiacritics,
+                            onClick = { config.onCommentClick(commentary) },
+                        )
+                    }
+                }
+
+                // Loading states
+                when (val loadState = lazyPagingItems.loadState.refresh) {
+                    is LoadState.Loading -> {
+                        item { LoadingIndicator() }
+                    }
+
+                    is LoadState.Error -> {
+                        item {
+                            ErrorMessage(loadState.error)
                         }
                     }
-                },
-    ) {
-        items(
-            count = lazyPagingItems.itemCount,
-            key = { index -> lazyPagingItems[index]?.link?.id ?: index }, // Clé stable
-        ) { index ->
-            lazyPagingItems[index]?.let { commentary ->
-                CommentaryItem(
-                    linkId = commentary.link.id,
-                    targetText = commentary.targetText,
-                    textSizes = config.textSizes,
-                    fontFamily = config.fontFamily,
-                    boldScale = config.boldScale,
-                    highlightQuery = highlightQuery,
-                    showDiacritics = config.showDiacritics,
-                    onClick = { config.onCommentClick(commentary) },
-                )
-            }
-        }
 
-        // Loading states
-        when (val loadState = lazyPagingItems.loadState.refresh) {
-            is LoadState.Loading -> {
-                item { LoadingIndicator() }
-            }
-
-            is LoadState.Error -> {
-                item {
-                    ErrorMessage(loadState.error)
+                    else -> {}
                 }
             }
-
-            else -> {}
         }
     }
 }
@@ -1017,15 +1013,13 @@ private fun CommentaryItem(
                 }
             }
 
-        SelectionContainer {
-            Text(
-                text = display,
-                textAlign = TextAlign.Justify,
-                fontFamily = fontFamily,
-                lineHeight = (textSizes.commentTextSize * textSizes.lineHeight).sp,
-                inlineContent = inlineImageContent,
-            )
-        }
+        Text(
+            text = display,
+            textAlign = TextAlign.Justify,
+            fontFamily = fontFamily,
+            lineHeight = (textSizes.commentTextSize * textSizes.lineHeight).sp,
+            inlineContent = inlineImageContent,
+        )
     }
 }
 

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.InlineTextContent
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -49,8 +48,8 @@ import io.github.kdroidfilter.seforimapp.features.bookcontent.state.CommentatorI
 import io.github.kdroidfilter.seforimapp.features.bookcontent.state.LineConnectionsSnapshot
 import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.EnhancedHorizontalSplitPane
 import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.PaneHeader
+import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.SafeSelectionContainer
 import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.asStable
-import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.consumeShiftPrimaryPress
 import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import io.github.kdroidfilter.seforimapp.icons.LayoutSidebarRight
 import io.github.kdroidfilter.seforimapp.icons.LayoutSidebarRightOff
@@ -564,29 +563,27 @@ private fun MultiLineCommentaryListView(
             .collect { (i, o) -> currentOnScroll(i, o) }
     }
 
-    Box(modifier = Modifier.fillMaxSize().consumeShiftPrimaryPress()) {
-        SelectionContainer {
-            VerticallyScrollableContainer(
-                scrollState = listState as ScrollableState,
-                scrollbarModifier = Modifier.fillMaxHeight(),
-            ) {
-                LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
-                    items(
-                        count = lazyPagingItems.itemCount,
-                        key = { index -> lazyPagingItems[index]?.link?.id ?: index },
-                    ) { index ->
-                        lazyPagingItems[index]?.let { commentary ->
-                            CommentaryItem(
-                                linkId = commentary.link.id,
-                                targetText = commentary.targetText,
-                                textSizes = config.textSizes,
-                                fontFamily = config.fontFamily,
-                                boldScale = config.boldScale,
-                                highlightQuery = highlightQuery,
-                                showDiacritics = config.showDiacritics,
-                                onClick = { config.onCommentClick(commentary) },
-                            )
-                        }
+    SafeSelectionContainer(modifier = Modifier.fillMaxSize()) {
+        VerticallyScrollableContainer(
+            scrollState = listState as ScrollableState,
+            scrollbarModifier = Modifier.fillMaxHeight(),
+        ) {
+            LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+                items(
+                    count = lazyPagingItems.itemCount,
+                    key = { index -> lazyPagingItems[index]?.link?.id ?: index },
+                ) { index ->
+                    lazyPagingItems[index]?.let { commentary ->
+                        CommentaryItem(
+                            linkId = commentary.link.id,
+                            targetText = commentary.targetText,
+                            textSizes = config.textSizes,
+                            fontFamily = config.fontFamily,
+                            boldScale = config.boldScale,
+                            highlightQuery = highlightQuery,
+                            showDiacritics = config.showDiacritics,
+                            onClick = { config.onCommentClick(commentary) },
+                        )
                     }
                 }
             }
@@ -889,44 +886,42 @@ private fun CommentaryListView(
             }
     }
 
-    Box(modifier = Modifier.fillMaxSize().consumeShiftPrimaryPress()) {
-        SelectionContainer {
-            LazyColumn(
-                state = listState,
-                modifier = Modifier.fillMaxSize(),
-            ) {
-                items(
-                    count = lazyPagingItems.itemCount,
-                    key = { index -> lazyPagingItems[index]?.link?.id ?: index }, // Clé stable
-                ) { index ->
-                    lazyPagingItems[index]?.let { commentary ->
-                        CommentaryItem(
-                            linkId = commentary.link.id,
-                            targetText = commentary.targetText,
-                            textSizes = config.textSizes,
-                            fontFamily = config.fontFamily,
-                            boldScale = config.boldScale,
-                            highlightQuery = highlightQuery,
-                            showDiacritics = config.showDiacritics,
-                            onClick = { config.onCommentClick(commentary) },
-                        )
+    SafeSelectionContainer(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            items(
+                count = lazyPagingItems.itemCount,
+                key = { index -> lazyPagingItems[index]?.link?.id ?: index }, // Clé stable
+            ) { index ->
+                lazyPagingItems[index]?.let { commentary ->
+                    CommentaryItem(
+                        linkId = commentary.link.id,
+                        targetText = commentary.targetText,
+                        textSizes = config.textSizes,
+                        fontFamily = config.fontFamily,
+                        boldScale = config.boldScale,
+                        highlightQuery = highlightQuery,
+                        showDiacritics = config.showDiacritics,
+                        onClick = { config.onCommentClick(commentary) },
+                    )
+                }
+            }
+
+            // Loading states
+            when (val loadState = lazyPagingItems.loadState.refresh) {
+                is LoadState.Loading -> {
+                    item { LoadingIndicator() }
+                }
+
+                is LoadState.Error -> {
+                    item {
+                        ErrorMessage(loadState.error)
                     }
                 }
 
-                // Loading states
-                when (val loadState = lazyPagingItems.loadState.refresh) {
-                    is LoadState.Loading -> {
-                        item { LoadingIndicator() }
-                    }
-
-                    is LoadState.Error -> {
-                        item {
-                            ErrorMessage(loadState.error)
-                        }
-                    }
-
-                    else -> {}
-                }
+                else -> {}
             }
         }
     }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineTargumView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineTargumView.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.InlineTextContent
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.*
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
@@ -43,7 +42,7 @@ import io.github.kdroidfilter.seforimapp.features.bookcontent.BookContentEvent
 import io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookContentState
 import io.github.kdroidfilter.seforimapp.features.bookcontent.state.LineConnectionsSnapshot
 import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.PaneHeader
-import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.consumeShiftPrimaryPress
+import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.SafeSelectionContainer
 import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import io.github.kdroidfilter.seforimlibrary.core.models.ConnectionType
 import io.github.kdroidfilter.seforimlibrary.core.models.Line
@@ -225,68 +224,66 @@ private fun SingleLineTargumView(
                                 .collect { (index, offset) -> currentOnScroll(index, offset) }
                         }
 
-                        Box(modifier = Modifier.fillMaxSize().consumeShiftPrimaryPress()) {
-                            SelectionContainer {
-                                LazyColumn(
-                                    modifier = Modifier.fillMaxSize(),
-                                    state = listState,
-                                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                                ) {
-                                    sourceSections.forEach { section ->
-                                        item(key = "header-${section.bookId}") {
-                                            Text(
-                                                text = section.title,
-                                                fontWeight = FontWeight.Bold,
-                                                fontSize = (commentTextSize * 1.1f).sp,
-                                                textAlign = TextAlign.Center,
-                                                modifier = Modifier.fillMaxWidth(),
+                        SafeSelectionContainer(modifier = Modifier.fillMaxSize()) {
+                            LazyColumn(
+                                modifier = Modifier.fillMaxSize(),
+                                state = listState,
+                                verticalArrangement = Arrangement.spacedBy(8.dp),
+                            ) {
+                                sourceSections.forEach { section ->
+                                    item(key = "header-${section.bookId}") {
+                                        Text(
+                                            text = section.title,
+                                            fontWeight = FontWeight.Bold,
+                                            fontSize = (commentTextSize * 1.1f).sp,
+                                            textAlign = TextAlign.Center,
+                                            modifier = Modifier.fillMaxWidth(),
+                                        )
+                                    }
+
+                                    items(
+                                        count = section.items.itemCount,
+                                        key = { index ->
+                                            section.items
+                                                .peek(index)
+                                                ?.link
+                                                ?.id ?: "source-${section.bookId}-$index"
+                                        },
+                                    ) { index ->
+                                        section.items[index]?.let { item ->
+                                            LinkItem(
+                                                linkId = item.link.id,
+                                                targetText = item.targetText,
+                                                commentTextSize = commentTextSize,
+                                                lineHeight = lineHeight,
+                                                fontFamily = targumFontFamily,
+                                                boldScale = boldScaleForPlatform,
+                                                highlightQuery = highlightQuery,
+                                                onClick = { onLinkClick(item) },
+                                                showDiacritics = showDiacritics,
                                             )
                                         }
+                                    }
 
-                                        items(
-                                            count = section.items.itemCount,
-                                            key = { index ->
-                                                section.items
-                                                    .peek(index)
-                                                    ?.link
-                                                    ?.id ?: "source-${section.bookId}-$index"
-                                            },
-                                        ) { index ->
-                                            section.items[index]?.let { item ->
-                                                LinkItem(
-                                                    linkId = item.link.id,
-                                                    targetText = item.targetText,
-                                                    commentTextSize = commentTextSize,
-                                                    lineHeight = lineHeight,
-                                                    fontFamily = targumFontFamily,
-                                                    boldScale = boldScaleForPlatform,
-                                                    highlightQuery = highlightQuery,
-                                                    onClick = { onLinkClick(item) },
-                                                    showDiacritics = showDiacritics,
-                                                )
+                                    when (val state = section.items.loadState.append) {
+                                        is LoadState.Error ->
+                                            item(key = "append-error-${section.bookId}") {
+                                                Box(
+                                                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                                                    contentAlignment = Alignment.Center,
+                                                ) {
+                                                    Text(text = state.error.message ?: "Error loading more")
+                                                }
                                             }
-                                        }
 
-                                        when (val state = section.items.loadState.append) {
-                                            is LoadState.Error ->
-                                                item(key = "append-error-${section.bookId}") {
-                                                    Box(
-                                                        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-                                                        contentAlignment = Alignment.Center,
-                                                    ) {
-                                                        Text(text = state.error.message ?: "Error loading more")
-                                                    }
+                                        is LoadState.Loading ->
+                                            item(key = "append-loading-${section.bookId}") {
+                                                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                                                    CircularProgressIndicator()
                                                 }
+                                            }
 
-                                            is LoadState.Loading ->
-                                                item(key = "append-loading-${section.bookId}") {
-                                                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                                                        CircularProgressIndicator()
-                                                    }
-                                                }
-
-                                            else -> {}
-                                        }
+                                        else -> {}
                                     }
                                 }
                             }
@@ -546,78 +543,76 @@ private fun MultiLineTargumView(
                         }
                 }
 
-                Box(modifier = Modifier.fillMaxSize().consumeShiftPrimaryPress()) {
-                    SelectionContainer {
-                        LazyColumn(
-                            modifier = Modifier.fillMaxSize(),
-                            state = listState,
-                            verticalArrangement = Arrangement.spacedBy(8.dp),
-                        ) {
-                            sourceSections.forEach { section ->
-                                item(key = "header-${section.bookId}") {
-                                    Text(
-                                        text = section.title,
-                                        fontWeight = FontWeight.Bold,
-                                        fontSize = (commentTextSize * 1.1f).sp,
-                                        textAlign = TextAlign.Center,
-                                        modifier = Modifier.fillMaxWidth(),
+                SafeSelectionContainer(modifier = Modifier.fillMaxSize()) {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        state = listState,
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        sourceSections.forEach { section ->
+                            item(key = "header-${section.bookId}") {
+                                Text(
+                                    text = section.title,
+                                    fontWeight = FontWeight.Bold,
+                                    fontSize = (commentTextSize * 1.1f).sp,
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                            }
+
+                            items(
+                                count = section.items.itemCount,
+                                key = { index ->
+                                    section.items
+                                        .peek(index)
+                                        ?.link
+                                        ?.id ?: "multi-source-${section.bookId}-$index"
+                                },
+                            ) { index ->
+                                section.items[index]?.let { item ->
+                                    LinkItem(
+                                        linkId = item.link.id,
+                                        targetText = item.targetText,
+                                        commentTextSize = commentTextSize,
+                                        lineHeight = lineHeight,
+                                        fontFamily = targumFontFamily,
+                                        boldScale = boldScaleForPlatform,
+                                        highlightQuery = highlightQuery,
+                                        onClick = {
+                                            val mods = windowInfo.keyboardModifiers
+                                            if (mods.isCtrlPressed || mods.isMetaPressed) {
+                                                onEvent(
+                                                    BookContentEvent.OpenCommentaryTarget(
+                                                        bookId = item.link.targetBookId,
+                                                        lineId = item.link.targetLineId,
+                                                    ),
+                                                )
+                                            }
+                                        },
+                                        showDiacritics = showDiacritics,
                                     )
                                 }
+                            }
 
-                                items(
-                                    count = section.items.itemCount,
-                                    key = { index ->
-                                        section.items
-                                            .peek(index)
-                                            ?.link
-                                            ?.id ?: "multi-source-${section.bookId}-$index"
-                                    },
-                                ) { index ->
-                                    section.items[index]?.let { item ->
-                                        LinkItem(
-                                            linkId = item.link.id,
-                                            targetText = item.targetText,
-                                            commentTextSize = commentTextSize,
-                                            lineHeight = lineHeight,
-                                            fontFamily = targumFontFamily,
-                                            boldScale = boldScaleForPlatform,
-                                            highlightQuery = highlightQuery,
-                                            onClick = {
-                                                val mods = windowInfo.keyboardModifiers
-                                                if (mods.isCtrlPressed || mods.isMetaPressed) {
-                                                    onEvent(
-                                                        BookContentEvent.OpenCommentaryTarget(
-                                                            bookId = item.link.targetBookId,
-                                                            lineId = item.link.targetLineId,
-                                                        ),
-                                                    )
-                                                }
-                                            },
-                                            showDiacritics = showDiacritics,
-                                        )
+                            when (val state = section.items.loadState.append) {
+                                is LoadState.Error ->
+                                    item(key = "append-error-${section.bookId}") {
+                                        Box(
+                                            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                                            contentAlignment = Alignment.Center,
+                                        ) {
+                                            Text(text = state.error.message ?: "Error loading more")
+                                        }
                                     }
-                                }
 
-                                when (val state = section.items.loadState.append) {
-                                    is LoadState.Error ->
-                                        item(key = "append-error-${section.bookId}") {
-                                            Box(
-                                                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-                                                contentAlignment = Alignment.Center,
-                                            ) {
-                                                Text(text = state.error.message ?: "Error loading more")
-                                            }
+                                is LoadState.Loading ->
+                                    item(key = "append-loading-${section.bookId}") {
+                                        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                                            CircularProgressIndicator()
                                         }
+                                    }
 
-                                    is LoadState.Loading ->
-                                        item(key = "append-loading-${section.bookId}") {
-                                            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                                                CircularProgressIndicator()
-                                            }
-                                        }
-
-                                    else -> {}
-                                }
+                                else -> {}
                             }
                         }
                     }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineTargumView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineTargumView.kt
@@ -43,6 +43,7 @@ import io.github.kdroidfilter.seforimapp.features.bookcontent.BookContentEvent
 import io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookContentState
 import io.github.kdroidfilter.seforimapp.features.bookcontent.state.LineConnectionsSnapshot
 import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.PaneHeader
+import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.consumeShiftPrimaryPress
 import io.github.kdroidfilter.seforimapp.framework.platform.PlatformInfo
 import io.github.kdroidfilter.seforimlibrary.core.models.ConnectionType
 import io.github.kdroidfilter.seforimlibrary.core.models.Line
@@ -224,66 +225,68 @@ private fun SingleLineTargumView(
                                 .collect { (index, offset) -> currentOnScroll(index, offset) }
                         }
 
-                        SelectionContainer {
-                            LazyColumn(
-                                modifier = Modifier.fillMaxSize(),
-                                state = listState,
-                                verticalArrangement = Arrangement.spacedBy(8.dp),
-                            ) {
-                                sourceSections.forEach { section ->
-                                    item(key = "header-${section.bookId}") {
-                                        Text(
-                                            text = section.title,
-                                            fontWeight = FontWeight.Bold,
-                                            fontSize = (commentTextSize * 1.1f).sp,
-                                            textAlign = TextAlign.Center,
-                                            modifier = Modifier.fillMaxWidth(),
-                                        )
-                                    }
-
-                                    items(
-                                        count = section.items.itemCount,
-                                        key = { index ->
-                                            section.items
-                                                .peek(index)
-                                                ?.link
-                                                ?.id ?: "source-${section.bookId}-$index"
-                                        },
-                                    ) { index ->
-                                        section.items[index]?.let { item ->
-                                            LinkItem(
-                                                linkId = item.link.id,
-                                                targetText = item.targetText,
-                                                commentTextSize = commentTextSize,
-                                                lineHeight = lineHeight,
-                                                fontFamily = targumFontFamily,
-                                                boldScale = boldScaleForPlatform,
-                                                highlightQuery = highlightQuery,
-                                                onClick = { onLinkClick(item) },
-                                                showDiacritics = showDiacritics,
+                        Box(modifier = Modifier.fillMaxSize().consumeShiftPrimaryPress()) {
+                            SelectionContainer {
+                                LazyColumn(
+                                    modifier = Modifier.fillMaxSize(),
+                                    state = listState,
+                                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    sourceSections.forEach { section ->
+                                        item(key = "header-${section.bookId}") {
+                                            Text(
+                                                text = section.title,
+                                                fontWeight = FontWeight.Bold,
+                                                fontSize = (commentTextSize * 1.1f).sp,
+                                                textAlign = TextAlign.Center,
+                                                modifier = Modifier.fillMaxWidth(),
                                             )
                                         }
-                                    }
 
-                                    when (val state = section.items.loadState.append) {
-                                        is LoadState.Error ->
-                                            item(key = "append-error-${section.bookId}") {
-                                                Box(
-                                                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-                                                    contentAlignment = Alignment.Center,
-                                                ) {
-                                                    Text(text = state.error.message ?: "Error loading more")
-                                                }
+                                        items(
+                                            count = section.items.itemCount,
+                                            key = { index ->
+                                                section.items
+                                                    .peek(index)
+                                                    ?.link
+                                                    ?.id ?: "source-${section.bookId}-$index"
+                                            },
+                                        ) { index ->
+                                            section.items[index]?.let { item ->
+                                                LinkItem(
+                                                    linkId = item.link.id,
+                                                    targetText = item.targetText,
+                                                    commentTextSize = commentTextSize,
+                                                    lineHeight = lineHeight,
+                                                    fontFamily = targumFontFamily,
+                                                    boldScale = boldScaleForPlatform,
+                                                    highlightQuery = highlightQuery,
+                                                    onClick = { onLinkClick(item) },
+                                                    showDiacritics = showDiacritics,
+                                                )
                                             }
+                                        }
 
-                                        is LoadState.Loading ->
-                                            item(key = "append-loading-${section.bookId}") {
-                                                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                                                    CircularProgressIndicator()
+                                        when (val state = section.items.loadState.append) {
+                                            is LoadState.Error ->
+                                                item(key = "append-error-${section.bookId}") {
+                                                    Box(
+                                                        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                                                        contentAlignment = Alignment.Center,
+                                                    ) {
+                                                        Text(text = state.error.message ?: "Error loading more")
+                                                    }
                                                 }
-                                            }
 
-                                        else -> {}
+                                            is LoadState.Loading ->
+                                                item(key = "append-loading-${section.bookId}") {
+                                                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                                                        CircularProgressIndicator()
+                                                    }
+                                                }
+
+                                            else -> {}
+                                        }
                                     }
                                 }
                             }
@@ -543,76 +546,78 @@ private fun MultiLineTargumView(
                         }
                 }
 
-                SelectionContainer {
-                    LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
-                        state = listState,
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        sourceSections.forEach { section ->
-                            item(key = "header-${section.bookId}") {
-                                Text(
-                                    text = section.title,
-                                    fontWeight = FontWeight.Bold,
-                                    fontSize = (commentTextSize * 1.1f).sp,
-                                    textAlign = TextAlign.Center,
-                                    modifier = Modifier.fillMaxWidth(),
-                                )
-                            }
-
-                            items(
-                                count = section.items.itemCount,
-                                key = { index ->
-                                    section.items
-                                        .peek(index)
-                                        ?.link
-                                        ?.id ?: "multi-source-${section.bookId}-$index"
-                                },
-                            ) { index ->
-                                section.items[index]?.let { item ->
-                                    LinkItem(
-                                        linkId = item.link.id,
-                                        targetText = item.targetText,
-                                        commentTextSize = commentTextSize,
-                                        lineHeight = lineHeight,
-                                        fontFamily = targumFontFamily,
-                                        boldScale = boldScaleForPlatform,
-                                        highlightQuery = highlightQuery,
-                                        onClick = {
-                                            val mods = windowInfo.keyboardModifiers
-                                            if (mods.isCtrlPressed || mods.isMetaPressed) {
-                                                onEvent(
-                                                    BookContentEvent.OpenCommentaryTarget(
-                                                        bookId = item.link.targetBookId,
-                                                        lineId = item.link.targetLineId,
-                                                    ),
-                                                )
-                                            }
-                                        },
-                                        showDiacritics = showDiacritics,
+                Box(modifier = Modifier.fillMaxSize().consumeShiftPrimaryPress()) {
+                    SelectionContainer {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            state = listState,
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            sourceSections.forEach { section ->
+                                item(key = "header-${section.bookId}") {
+                                    Text(
+                                        text = section.title,
+                                        fontWeight = FontWeight.Bold,
+                                        fontSize = (commentTextSize * 1.1f).sp,
+                                        textAlign = TextAlign.Center,
+                                        modifier = Modifier.fillMaxWidth(),
                                     )
                                 }
-                            }
 
-                            when (val state = section.items.loadState.append) {
-                                is LoadState.Error ->
-                                    item(key = "append-error-${section.bookId}") {
-                                        Box(
-                                            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-                                            contentAlignment = Alignment.Center,
-                                        ) {
-                                            Text(text = state.error.message ?: "Error loading more")
-                                        }
+                                items(
+                                    count = section.items.itemCount,
+                                    key = { index ->
+                                        section.items
+                                            .peek(index)
+                                            ?.link
+                                            ?.id ?: "multi-source-${section.bookId}-$index"
+                                    },
+                                ) { index ->
+                                    section.items[index]?.let { item ->
+                                        LinkItem(
+                                            linkId = item.link.id,
+                                            targetText = item.targetText,
+                                            commentTextSize = commentTextSize,
+                                            lineHeight = lineHeight,
+                                            fontFamily = targumFontFamily,
+                                            boldScale = boldScaleForPlatform,
+                                            highlightQuery = highlightQuery,
+                                            onClick = {
+                                                val mods = windowInfo.keyboardModifiers
+                                                if (mods.isCtrlPressed || mods.isMetaPressed) {
+                                                    onEvent(
+                                                        BookContentEvent.OpenCommentaryTarget(
+                                                            bookId = item.link.targetBookId,
+                                                            lineId = item.link.targetLineId,
+                                                        ),
+                                                    )
+                                                }
+                                            },
+                                            showDiacritics = showDiacritics,
+                                        )
                                     }
+                                }
 
-                                is LoadState.Loading ->
-                                    item(key = "append-loading-${section.bookId}") {
-                                        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                                            CircularProgressIndicator()
+                                when (val state = section.items.loadState.append) {
+                                    is LoadState.Error ->
+                                        item(key = "append-error-${section.bookId}") {
+                                            Box(
+                                                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                                                contentAlignment = Alignment.Center,
+                                            ) {
+                                                Text(text = state.error.message ?: "Error loading more")
+                                            }
                                         }
-                                    }
 
-                                else -> {}
+                                    is LoadState.Loading ->
+                                        item(key = "append-loading-${section.bookId}") {
+                                            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                                                CircularProgressIndicator()
+                                            }
+                                        }
+
+                                    else -> {}
+                                }
                             }
                         }
                     }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/database/DatabaseVersionManager.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/database/DatabaseVersionManager.kt
@@ -13,7 +13,7 @@ object DatabaseVersionManager {
      * Minimum required database version for this application release.
      * This should be updated when database schema or data structure changes.
      */
-    private const val MINIMUM_REQUIRED_VERSION = "20260111222851"
+    private const val MINIMUM_REQUIRED_VERSION = "20260422161147"
 
     /**
      * Gets the current database version by reading the release_info.txt file


### PR DESCRIPTION
## Summary
- Apply the same virtualized-list selection workaround used in `BookContentView` (issue #48) to the commentaries, sources and targum panels — drag-select now spans multiple sections, and Shift+Click extension no longer crashes Compose.
- Extract `Modifier.consumeShiftPrimaryPress()` helper to keep the Shift+primary consume hack in one place.
- `LineCommentsView`: single outer `SelectionContainer` around both `CommentaryListView` and `MultiLineCommentaryListView`; per-item `SelectionContainer` on `CommentaryItem` removed.
- `LineTargumView`: wrap the existing outer `SelectionContainer` of `SingleLineTargumView` and `MultiLineTargumView` in a `Box` that consumes Shift+primary presses during the `Initial` pass.

Closes #352.

## Test plan
- [x] Mefarshim: drag-select across 2+ commentary items — selection stays continuous
- [x] Mekorot: drag-select across 2+ sources — selection stays continuous
- [x] Targum: drag-select across 2+ sections — selection stays continuous
- [x] Shift+Click to extend a selection in each panel — no Compose crash
- [x] Ctrl/Cmd+Click on a commentary or link still opens the target
- [x] Multi-line (Ctrl+click) mode for commentaries and targum still selects correctly