### PR TITLE
refactor(commentaries): dedupe single/multi-line list + level asymmetries

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
@@ -47,6 +47,7 @@ import io.github.kdroidfilter.seforimapp.features.bookcontent.state.BookContentS
 import io.github.kdroidfilter.seforimapp.features.bookcontent.state.CommentatorGroup
 import io.github.kdroidfilter.seforimapp.features.bookcontent.state.CommentatorItem
 import io.github.kdroidfilter.seforimapp.features.bookcontent.state.LineConnectionsSnapshot
+import io.github.kdroidfilter.seforimapp.features.bookcontent.state.Providers
 import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.EnhancedHorizontalSplitPane
 import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.PaneHeader
 import io.github.kdroidfilter.seforimapp.features.bookcontent.ui.components.SafeSelectionContainer
@@ -244,7 +245,7 @@ private fun CommentariesContent(
             CommentariesDisplay(
                 selectedCommentators = selectedInDisplayOrder,
                 titleToIdMap = titleToIdMap,
-                selectedLineId = selectedLineId,
+                selection = LineSelection.Single(selectedLineId),
                 uiState = uiState,
                 onEvent = onEvent,
                 textSizes = textSizes,
@@ -349,10 +350,10 @@ private fun MultiLineCommentariesContent(
                 remember(commentatorsInDisplayOrder, selectedCommentators.value) {
                     commentatorsInDisplayOrder.filter { it in selectedCommentators.value }.toImmutableList()
                 }
-            MultiLineCommentariesDisplay(
+            CommentariesDisplay(
                 selectedCommentators = selectedInDisplayOrder,
                 titleToIdMap = titleToIdMap,
-                selectedLineIds = selectedLineIds,
+                selection = LineSelection.Multi(selectedLineIds),
                 uiState = uiState,
                 onEvent = onEvent,
                 textSizes = textSizes,
@@ -361,82 +362,6 @@ private fun MultiLineCommentariesContent(
             )
         },
     )
-}
-
-/**
- * Multi-line version of CommentariesDisplay.
- * Uses the multi-line pager to aggregate commentaries from all selected lines.
- */
-@Composable
-private fun MultiLineCommentariesDisplay(
-    selectedCommentators: ImmutableList<String>,
-    titleToIdMap: Map<String, Long>,
-    selectedLineIds: ImmutableList<Long>,
-    uiState: BookContentState,
-    onEvent: (BookContentEvent) -> Unit,
-    textSizes: AnimatedTextSizes,
-    findQueryText: String,
-    showDiacritics: Boolean,
-) {
-    if (selectedCommentators.isEmpty()) {
-        CenteredMessage(
-            message = stringResource(Res.string.select_at_least_one_commentator),
-            fontSize = textSizes.commentTextSize,
-        )
-        return
-    }
-
-    val layoutConfig =
-        rememberCommentariesLayoutConfig(
-            selectedCommentators = selectedCommentators,
-            titleToIdMap = titleToIdMap,
-            textSizes = textSizes,
-            findQueryText = findQueryText,
-            showDiacritics = showDiacritics,
-            onEvent = onEvent,
-        )
-
-    MultiLineCommentatorsGridView(
-        config = layoutConfig,
-        lineIds = selectedLineIds,
-        uiState = uiState,
-        onEvent = onEvent,
-    )
-}
-
-/**
- * Grid view for multi-line commentaries.
- */
-@Composable
-private fun MultiLineCommentatorsGridView(
-    config: CommentariesLayoutConfig,
-    lineIds: ImmutableList<Long>,
-    uiState: BookContentState,
-    onEvent: (BookContentEvent) -> Unit,
-) {
-    val providers = uiState.providers ?: return
-    CommentatorsGridScaffold(config = config) { commentatorId ->
-        val pagerFlow =
-            remember(lineIds, commentatorId) {
-                providers.buildCommentariesPagerForLines(lineIds, commentatorId)
-            }
-        val initialIndex =
-            uiState.content.commentariesColumnScrollIndexByCommentator[commentatorId]
-                ?: uiState.content.commentariesScrollIndex
-        val initialOffset =
-            uiState.content.commentariesColumnScrollOffsetByCommentator[commentatorId]
-                ?: uiState.content.commentariesScrollOffset
-        CommentariesPagedList(
-            pagerFlow = pagerFlow,
-            initialIndex = initialIndex,
-            initialOffset = initialOffset,
-            onScroll = { i, o ->
-                onEvent(BookContentEvent.CommentaryColumnScrolled(commentatorId, i, o))
-            },
-            config = config,
-            restoreScrollKey = lineIds to commentatorId,
-        )
-    }
 }
 
 @OptIn(FlowPreview::class)
@@ -523,7 +448,7 @@ private fun CommentatorsList(
 private fun CommentariesDisplay(
     selectedCommentators: ImmutableList<String>,
     titleToIdMap: Map<String, Long>,
-    selectedLineId: Long,
+    selection: LineSelection,
     uiState: BookContentState,
     onEvent: (BookContentEvent) -> Unit,
     textSizes: AnimatedTextSizes,
@@ -548,26 +473,26 @@ private fun CommentariesDisplay(
             onEvent = onEvent,
         )
 
-    CommentatorsGridView(
+    CommentatorsGrid(
         config = layoutConfig,
-        lineId = selectedLineId,
+        selection = selection,
         uiState = uiState,
         onEvent = onEvent,
     )
 }
 
 @Composable
-private fun CommentatorsGridView(
+private fun CommentatorsGrid(
     config: CommentariesLayoutConfig,
-    lineId: Long,
+    selection: LineSelection,
     uiState: BookContentState,
     onEvent: (BookContentEvent) -> Unit,
 ) {
     val providers = uiState.providers ?: return
     CommentatorsGridScaffold(config = config) { commentatorId ->
         val pagerFlow =
-            remember(lineId, commentatorId) {
-                providers.buildCommentariesPagerFor(lineId, commentatorId)
+            remember(selection, commentatorId) {
+                providers.buildCommentariesPagerFor(selection, commentatorId)
             }
         val initialIndex =
             uiState.content.commentariesColumnScrollIndexByCommentator[commentatorId]
@@ -583,7 +508,6 @@ private fun CommentatorsGridView(
                 onEvent(BookContentEvent.CommentaryColumnScrolled(commentatorId, i, o))
             },
             config = config,
-            restoreScrollKey = lineId to commentatorId,
         )
     }
 }
@@ -643,9 +567,9 @@ private fun buildCommentatorRows(selected: List<String>): List<List<String>> =
  * Paged list of [CommentaryItem]s for one commentator, wrapped in a [SafeSelectionContainer].
  * Shared by single-line and multi-line views.
  *
- * [restoreScrollKey] identifies the pager source — it drives the "restore scroll on first
- * refresh" logic and must have a stable structural equality (e.g. a primitive or a [Pair] of
- * primitives/immutable collections). Do not pass a lambda or an object without `equals`.
+ * The pager identity ([pagerFlow]) itself drives the "restore scroll on first refresh" logic:
+ * callers build it via `remember(lineKey, commentatorId) { ... }`, so a new pager instance
+ * signals a new source of lines and resets the one-shot restore.
  */
 @OptIn(FlowPreview::class)
 @Composable
@@ -655,7 +579,6 @@ private fun CommentariesPagedList(
     initialOffset: Int,
     onScroll: (Int, Int) -> Unit,
     config: CommentariesLayoutConfig,
-    restoreScrollKey: Any,
 ) {
     val currentOnScroll by rememberUpdatedState(onScroll)
     val lazyPagingItems = pagerFlow.collectAsLazyPagingItems()
@@ -666,8 +589,8 @@ private fun CommentariesPagedList(
             initialFirstVisibleItemScrollOffset = initialOffset,
         )
 
-    var hasRestored by remember(restoreScrollKey) { mutableStateOf(false) }
-    LaunchedEffect(restoreScrollKey, lazyPagingItems.loadState.refresh, initialIndex, initialOffset) {
+    var hasRestored by remember(pagerFlow) { mutableStateOf(false) }
+    LaunchedEffect(pagerFlow, lazyPagingItems.loadState.refresh, initialIndex, initialOffset) {
         if (!hasRestored && lazyPagingItems.loadState.refresh !is LoadState.Loading) {
             if (lazyPagingItems.itemCount > 0) {
                 val safeIndex = initialIndex.coerceIn(0, lazyPagingItems.itemCount - 1)
@@ -1019,6 +942,29 @@ private data class AnimatedTextSizes(
     val commentTextSize: Float,
     val lineHeight: Float,
 )
+
+/**
+ * Source of lines feeding a commentary view: either a single selected line or a manual
+ * multi-selection. Chooses which provider pager to build in [Providers.buildCommentariesPagerFor].
+ */
+private sealed interface LineSelection {
+    data class Single(
+        val lineId: Long,
+    ) : LineSelection
+
+    data class Multi(
+        val lineIds: ImmutableList<Long>,
+    ) : LineSelection
+}
+
+private fun Providers.buildCommentariesPagerFor(
+    selection: LineSelection,
+    commentatorId: Long,
+): Flow<PagingData<CommentaryWithText>> =
+    when (selection) {
+        is LineSelection.Single -> buildCommentariesPagerFor(selection.lineId, commentatorId)
+        is LineSelection.Multi -> buildCommentariesPagerForLines(selection.lineIds, commentatorId)
+    }
 
 /**
  * UI + callbacks shared between the single-line and multi-line commentary views.

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.runtime.*
@@ -34,7 +33,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.paging.LoadState
 import androidx.paging.PagingData
-import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import io.github.kdroidfilter.seforim.htmlparser.SkiaHtmlImageBuilder
 import io.github.kdroidfilter.seforim.htmlparser.buildAnnotatedFromHtml
@@ -436,8 +434,6 @@ private fun MultiLineCommentatorsGridView(
             },
             config = config,
             restoreScrollKey = lineIds to commentatorId,
-            showLoadingStates = true,
-            wrapInScrollableContainer = true,
         )
     }
 }
@@ -587,8 +583,6 @@ private fun CommentatorsGridView(
             },
             config = config,
             restoreScrollKey = lineId to commentatorId,
-            showLoadingStates = true,
-            wrapInScrollableContainer = true,
         )
     }
 }
@@ -645,8 +639,8 @@ private fun buildCommentatorRows(selected: List<String>): List<List<String>> =
     }
 
 /**
- * Paged list of [CommentaryItem]s for one commentator, wrapped in a [SafeSelectionContainer].
- * Shared by single-line and multi-line views; asymmetric behaviors are gated behind flags.
+ * Paged list of [CommentaryItem]s for one commentator, wrapped in a [SafeSelectionContainer]
+ * and a vertical scrollbar. Shared by single-line and multi-line views.
  */
 @OptIn(FlowPreview::class)
 @Composable
@@ -656,9 +650,7 @@ private fun CommentariesPagedList(
     initialOffset: Int,
     onScroll: (Int, Int) -> Unit,
     config: CommentariesLayoutConfig,
-    restoreScrollKey: Any?,
-    showLoadingStates: Boolean,
-    wrapInScrollableContainer: Boolean,
+    restoreScrollKey: Any,
 ) {
     val currentOnScroll by rememberUpdatedState(onScroll)
     val lazyPagingItems = pagerFlow.collectAsLazyPagingItems()
@@ -669,16 +661,14 @@ private fun CommentariesPagedList(
             initialFirstVisibleItemScrollOffset = initialOffset,
         )
 
-    if (restoreScrollKey != null) {
-        var hasRestored by remember(restoreScrollKey) { mutableStateOf(false) }
-        LaunchedEffect(restoreScrollKey, lazyPagingItems.loadState.refresh, initialIndex, initialOffset) {
-            if (!hasRestored && lazyPagingItems.loadState.refresh !is LoadState.Loading) {
-                if (lazyPagingItems.itemCount > 0) {
-                    val safeIndex = initialIndex.coerceIn(0, lazyPagingItems.itemCount - 1)
-                    val safeOffset = initialOffset.coerceAtLeast(0)
-                    listState.scrollToItem(safeIndex, safeOffset)
-                    hasRestored = true
-                }
+    var hasRestored by remember(restoreScrollKey) { mutableStateOf(false) }
+    LaunchedEffect(restoreScrollKey, lazyPagingItems.loadState.refresh, initialIndex, initialOffset) {
+        if (!hasRestored && lazyPagingItems.loadState.refresh !is LoadState.Loading) {
+            if (lazyPagingItems.itemCount > 0) {
+                val safeIndex = initialIndex.coerceIn(0, lazyPagingItems.itemCount - 1)
+                val safeOffset = initialOffset.coerceAtLeast(0)
+                listState.scrollToItem(safeIndex, safeOffset)
+                hasRestored = true
             }
         }
     }
@@ -691,60 +681,34 @@ private fun CommentariesPagedList(
     }
 
     SafeSelectionContainer(modifier = Modifier.fillMaxSize()) {
-        if (wrapInScrollableContainer) {
-            VerticallyScrollableContainer(
-                scrollState = listState as ScrollableState,
-                scrollbarModifier = Modifier.fillMaxHeight(),
-            ) {
-                CommentariesLazyColumn(
-                    listState = listState,
-                    lazyPagingItems = lazyPagingItems,
-                    config = config,
-                    showLoadingStates = showLoadingStates,
-                )
-            }
-        } else {
-            CommentariesLazyColumn(
-                listState = listState,
-                lazyPagingItems = lazyPagingItems,
-                config = config,
-                showLoadingStates = showLoadingStates,
-            )
-        }
-    }
-}
+        VerticallyScrollableContainer(
+            scrollState = listState as ScrollableState,
+            scrollbarModifier = Modifier.fillMaxHeight(),
+        ) {
+            LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+                items(
+                    count = lazyPagingItems.itemCount,
+                    key = { index -> lazyPagingItems[index]?.link?.id ?: index },
+                ) { index ->
+                    lazyPagingItems[index]?.let { commentary ->
+                        CommentaryItem(
+                            linkId = commentary.link.id,
+                            targetText = commentary.targetText,
+                            textSizes = config.textSizes,
+                            fontFamily = config.fontFamily,
+                            boldScale = config.boldScale,
+                            highlightQuery = config.highlightQuery,
+                            showDiacritics = config.showDiacritics,
+                            onClick = { config.onCommentClick(commentary) },
+                        )
+                    }
+                }
 
-@Composable
-private fun CommentariesLazyColumn(
-    listState: LazyListState,
-    lazyPagingItems: LazyPagingItems<CommentaryWithText>,
-    config: CommentariesLayoutConfig,
-    showLoadingStates: Boolean,
-) {
-    LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
-        items(
-            count = lazyPagingItems.itemCount,
-            key = { index -> lazyPagingItems[index]?.link?.id ?: index },
-        ) { index ->
-            lazyPagingItems[index]?.let { commentary ->
-                CommentaryItem(
-                    linkId = commentary.link.id,
-                    targetText = commentary.targetText,
-                    textSizes = config.textSizes,
-                    fontFamily = config.fontFamily,
-                    boldScale = config.boldScale,
-                    highlightQuery = config.highlightQuery,
-                    showDiacritics = config.showDiacritics,
-                    onClick = { config.onCommentClick(commentary) },
-                )
-            }
-        }
-
-        if (showLoadingStates) {
-            when (val loadState = lazyPagingItems.loadState.refresh) {
-                is LoadState.Loading -> item { LoadingIndicator() }
-                is LoadState.Error -> item { ErrorMessage(loadState.error) }
-                else -> {}
+                when (val loadState = lazyPagingItems.loadState.refresh) {
+                    is LoadState.Loading -> item { LoadingIndicator() }
+                    is LoadState.Error -> item { ErrorMessage(loadState.error) }
+                    else -> {}
+                }
             }
         }
     }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
@@ -588,7 +588,7 @@ private fun CommentatorsGridView(
             config = config,
             restoreScrollKey = lineId to commentatorId,
             showLoadingStates = true,
-            wrapInScrollableContainer = false,
+            wrapInScrollableContainer = true,
         )
     }
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
@@ -436,7 +436,7 @@ private fun MultiLineCommentatorsGridView(
             },
             config = config,
             restoreScrollKey = null,
-            showLoadingStates = false,
+            showLoadingStates = true,
             wrapInScrollableContainer = true,
         )
     }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
@@ -72,7 +72,7 @@ import seforimapp.seforimapp.generated.resources.*
 import kotlin.time.Duration.Companion.milliseconds
 
 private const val MAX_COMMENTATORS = 4
-private const val SCROLL_DEBOUNCE_MS = 100L
+private val SCROLL_DEBOUNCE = 100.milliseconds
 
 @OptIn(ExperimentalSplitPaneApi::class)
 @Composable
@@ -385,7 +385,7 @@ private fun CommentatorsList(
         LaunchedEffect(listState) {
             snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
                 .distinctUntilChanged()
-                .debounce(SCROLL_DEBOUNCE_MS.milliseconds)
+                .debounce(SCROLL_DEBOUNCE)
                 .collect { (i, o) -> currentOnScroll(i, o) }
         }
 
@@ -567,9 +567,11 @@ private fun buildCommentatorRows(selected: List<String>): List<List<String>> =
  * Paged list of [CommentaryItem]s for one commentator, wrapped in a [SafeSelectionContainer].
  * Shared by single-line and multi-line views.
  *
- * The pager identity ([pagerFlow]) itself drives the "restore scroll on first refresh" logic:
- * callers build it via `remember(lineKey, commentatorId) { ... }`, so a new pager instance
- * signals a new source of lines and resets the one-shot restore.
+ * IMPORTANT — [pagerFlow] identity drives the one-shot scroll restore. Callers MUST build it via
+ * `remember(key1, key2, ...) { providers.buildPagerFor(...) }` so that the same logical source
+ * yields the same [Flow] reference across recompositions. Passing a freshly-constructed Flow on
+ * every recomposition (e.g. inline `providers.buildPagerFor(...).map { ... }`) will reset the
+ * one-shot state on each frame and fight the user's scroll position.
  */
 @OptIn(FlowPreview::class)
 @Composable
@@ -604,7 +606,7 @@ private fun CommentariesPagedList(
     LaunchedEffect(listState) {
         snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
             .distinctUntilChanged()
-            .debounce(SCROLL_DEBOUNCE_MS.milliseconds)
+            .debounce(SCROLL_DEBOUNCE)
             .collect { (i, o) -> currentOnScroll(i, o) }
     }
 

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
@@ -415,7 +415,7 @@ private fun MultiLineCommentatorsGridView(
     onEvent: (BookContentEvent) -> Unit,
 ) {
     val providers = uiState.providers ?: return
-    CommentatorsGrid(config = config) { commentatorId ->
+    CommentatorsGridScaffold(config = config) { commentatorId ->
         val pagerFlow =
             remember(lineIds, commentatorId) {
                 providers.buildCommentariesPagerForLines(lineIds, commentatorId)
@@ -564,7 +564,7 @@ private fun CommentatorsGridView(
     onEvent: (BookContentEvent) -> Unit,
 ) {
     val providers = uiState.providers ?: return
-    CommentatorsGrid(config = config) { commentatorId ->
+    CommentatorsGridScaffold(config = config) { commentatorId ->
         val pagerFlow =
             remember(lineId, commentatorId) {
                 providers.buildCommentariesPagerFor(lineId, commentatorId)
@@ -593,7 +593,7 @@ private fun CommentatorsGridView(
  * renders one commentator column given its bookId.
  */
 @Composable
-private fun CommentatorsGrid(
+private fun CommentatorsGridScaffold(
     config: CommentariesLayoutConfig,
     column: @Composable (commentatorId: Long) -> Unit,
 ) {
@@ -640,8 +640,12 @@ private fun buildCommentatorRows(selected: List<String>): List<List<String>> =
     }
 
 /**
- * Paged list of [CommentaryItem]s for one commentator, wrapped in a [SafeSelectionContainer]
- * and a vertical scrollbar. Shared by single-line and multi-line views.
+ * Paged list of [CommentaryItem]s for one commentator, wrapped in a [SafeSelectionContainer].
+ * Shared by single-line and multi-line views.
+ *
+ * [restoreScrollKey] identifies the pager source — it drives the "restore scroll on first
+ * refresh" logic and must have a stable structural equality (e.g. a primitive or a [Pair] of
+ * primitives/immutable collections). Do not pass a lambda or an object without `equals`.
  */
 @OptIn(FlowPreview::class)
 @Composable
@@ -1016,6 +1020,13 @@ private data class AnimatedTextSizes(
     val lineHeight: Float,
 )
 
+/**
+ * UI + callbacks shared between the single-line and multi-line commentary views.
+ *
+ * Deliberately does not carry the line id(s) being displayed — the pager is built by the
+ * caller and injected via the [CommentatorsGridScaffold] column slot, so this config stays
+ * agnostic of single vs multi-line mode.
+ */
 @Immutable
 private data class CommentariesLayoutConfig(
     val selectedCommentators: ImmutableList<String>,

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.runtime.*
@@ -32,6 +33,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.paging.LoadState
+import androidx.paging.PagingData
+import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import io.github.kdroidfilter.seforim.htmlparser.SkiaHtmlImageBuilder
 import io.github.kdroidfilter.seforim.htmlparser.buildAnnotatedFromHtml
@@ -58,6 +61,7 @@ import io.github.kdroidfilter.seforimlibrary.dao.repository.CommentaryWithText
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import org.jetbrains.compose.resources.stringResource
@@ -234,7 +238,10 @@ private fun CommentariesContent(
         secondContent = {
             // Ensure selected commentators are always displayed in a stable order,
             // independent of the order in which they were selected.
-            val selectedInDisplayOrder = commentatorsInDisplayOrder.filter { it in selectedCommentators.value }
+            val selectedInDisplayOrder =
+                remember(commentatorsInDisplayOrder, selectedCommentators.value) {
+                    commentatorsInDisplayOrder.filter { it in selectedCommentators.value }.toImmutableList()
+                }
             CommentariesDisplay(
                 selectedCommentators = selectedInDisplayOrder,
                 titleToIdMap = titleToIdMap,
@@ -372,9 +379,6 @@ private fun MultiLineCommentariesDisplay(
     findQueryText: String,
     showDiacritics: Boolean,
 ) {
-    val contentState = uiState.content
-    val windowInfo = LocalWindowInfo.current
-
     if (selectedCommentators.isEmpty()) {
         CenteredMessage(
             message = stringResource(Res.string.select_at_least_one_commentator),
@@ -383,211 +387,58 @@ private fun MultiLineCommentariesDisplay(
         return
     }
 
-    val commentaryFontCode by AppSettings.commentaryFontCodeFlow.collectAsState()
-    val commentaryFontFamily = FontCatalog.familyFor(commentaryFontCode)
-    val boldScaleForPlatform =
-        remember(commentaryFontCode) {
-            val lacksBold = commentaryFontCode in setOf("notoserifhebrew", "notorashihebrew", "frankruhllibre")
-            if (PlatformInfo.isMacOS && lacksBold) 1.08f else 1.0f
-        }
-
-    // Build a layout config for multi-line mode
     val layoutConfig =
-        remember(
-            selectedCommentators,
-            titleToIdMap,
-            selectedLineIds,
-            contentState.commentariesScrollIndex,
-            contentState.commentariesScrollOffset,
-            textSizes,
-            commentaryFontFamily,
-            boldScaleForPlatform,
-            findQueryText,
-            showDiacritics,
-        ) {
-            MultiLineCommentariesLayoutConfig(
-                selectedCommentators = selectedCommentators,
-                titleToIdMap = titleToIdMap,
-                lineIds = selectedLineIds,
-                scrollIndex = contentState.commentariesScrollIndex,
-                scrollOffset = contentState.commentariesScrollOffset,
-                onScroll = { index, offset ->
-                    onEvent(BookContentEvent.CommentariesScrolled(index, offset))
-                },
-                onCommentClick = { commentary ->
-                    val mods = windowInfo.keyboardModifiers
-                    if (mods.isCtrlPressed || mods.isMetaPressed) {
-                        onEvent(
-                            BookContentEvent.OpenCommentaryTarget(
-                                bookId = commentary.link.targetBookId,
-                                lineId = commentary.link.targetLineId,
-                            ),
-                        )
-                    }
-                },
-                textSizes = textSizes,
-                fontFamily = commentaryFontFamily,
-                boldScale = boldScaleForPlatform,
-                highlightQuery = findQueryText,
-                showDiacritics = showDiacritics,
-            )
-        }
+        rememberCommentariesLayoutConfig(
+            selectedCommentators = selectedCommentators,
+            titleToIdMap = titleToIdMap,
+            textSizes = textSizes,
+            findQueryText = findQueryText,
+            showDiacritics = showDiacritics,
+            onEvent = onEvent,
+        )
 
-    MultiLineCommentatorsGridView(layoutConfig, uiState, onEvent)
+    MultiLineCommentatorsGridView(
+        config = layoutConfig,
+        lineIds = selectedLineIds,
+        uiState = uiState,
+        onEvent = onEvent,
+    )
 }
-
-/**
- * Multi-line config, similar to CommentariesLayoutConfig but with multiple line IDs.
- */
-@Stable
-private data class MultiLineCommentariesLayoutConfig(
-    val selectedCommentators: ImmutableList<String>,
-    val titleToIdMap: Map<String, Long>,
-    val lineIds: ImmutableList<Long>,
-    val scrollIndex: Int,
-    val scrollOffset: Int,
-    val onScroll: (Int, Int) -> Unit,
-    val onCommentClick: (CommentaryWithText) -> Unit,
-    val textSizes: AnimatedTextSizes,
-    val fontFamily: FontFamily,
-    val boldScale: Float,
-    val highlightQuery: String,
-    val showDiacritics: Boolean,
-)
 
 /**
  * Grid view for multi-line commentaries.
  */
 @Composable
 private fun MultiLineCommentatorsGridView(
-    config: MultiLineCommentariesLayoutConfig,
+    config: CommentariesLayoutConfig,
+    lineIds: ImmutableList<Long>,
     uiState: BookContentState,
     onEvent: (BookContentEvent) -> Unit,
 ) {
-    val rows =
-        remember(config.selectedCommentators) {
-            buildCommentatorRows(config.selectedCommentators)
-        }
-
-    var primaryAssigned = false
-
-    Column(modifier = Modifier.fillMaxSize()) {
-        rows.forEachIndexed { rowIndex, rowCommentators ->
-            val rowModifier =
-                remember(rows.size) {
-                    if (rows.size > 1) Modifier.weight(1f) else Modifier.fillMaxHeight()
-                }
-            Row(modifier = rowModifier.fillMaxWidth()) {
-                rowCommentators.forEachIndexed { colIndex, name ->
-                    val id = config.titleToIdMap[name] ?: return@forEachIndexed
-                    val isPrimary =
-                        remember(primaryAssigned) {
-                            if (!primaryAssigned) {
-                                primaryAssigned = true
-                                true
-                            } else {
-                                false
-                            }
-                        }
-                    val singleRowSingleCol = rows.size == 1 && rowCommentators.size == 1
-                    val colModifier =
-                        remember(singleRowSingleCol) {
-                            if (singleRowSingleCol) {
-                                Modifier.fillMaxHeight().weight(1f)
-                            } else {
-                                Modifier.weight(1f).padding(horizontal = 4.dp)
-                            }
-                        }
-                    Column(modifier = colModifier) {
-                        CommentatorHeader(name, config.textSizes.commentTextSize)
-                        MultiLineCommentaryListView(
-                            lineIds = config.lineIds,
-                            commentatorId = id,
-                            isPrimary = isPrimary,
-                            config = config,
-                            uiState = uiState,
-                            initialIndex =
-                                uiState.content.commentariesColumnScrollIndexByCommentator[id]
-                                    ?: uiState.content.commentariesScrollIndex,
-                            initialOffset =
-                                uiState.content.commentariesColumnScrollOffsetByCommentator[id]
-                                    ?: uiState.content.commentariesScrollOffset,
-                            onScroll = { i, o ->
-                                onEvent(BookContentEvent.CommentaryColumnScrolled(id, i, o))
-                            },
-                            highlightQuery = config.highlightQuery,
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-/**
- * List view for multi-line commentaries, using the multi-line pager.
- */
-@OptIn(FlowPreview::class)
-@Composable
-private fun MultiLineCommentaryListView(
-    lineIds: List<Long>,
-    commentatorId: Long,
-    isPrimary: Boolean,
-    config: MultiLineCommentariesLayoutConfig,
-    uiState: BookContentState,
-    initialIndex: Int,
-    initialOffset: Int,
-    onScroll: (Int, Int) -> Unit,
-    highlightQuery: String,
-) {
     val providers = uiState.providers ?: return
-    val currentOnScroll by rememberUpdatedState(onScroll)
-
-    val pagerFlow =
-        remember(lineIds, commentatorId) {
-            providers.buildCommentariesPagerForLines(lineIds, commentatorId)
-        }
-
-    val lazyPagingItems = pagerFlow.collectAsLazyPagingItems()
-
-    val listState =
-        rememberLazyListState(
-            initialFirstVisibleItemIndex = initialIndex,
-            initialFirstVisibleItemScrollOffset = initialOffset,
-        )
-
-    LaunchedEffect(listState) {
-        snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
-            .distinctUntilChanged()
-            .debounce(SCROLL_DEBOUNCE_MS)
-            .collect { (i, o) -> currentOnScroll(i, o) }
-    }
-
-    SafeSelectionContainer(modifier = Modifier.fillMaxSize()) {
-        VerticallyScrollableContainer(
-            scrollState = listState as ScrollableState,
-            scrollbarModifier = Modifier.fillMaxHeight(),
-        ) {
-            LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
-                items(
-                    count = lazyPagingItems.itemCount,
-                    key = { index -> lazyPagingItems[index]?.link?.id ?: index },
-                ) { index ->
-                    lazyPagingItems[index]?.let { commentary ->
-                        CommentaryItem(
-                            linkId = commentary.link.id,
-                            targetText = commentary.targetText,
-                            textSizes = config.textSizes,
-                            fontFamily = config.fontFamily,
-                            boldScale = config.boldScale,
-                            highlightQuery = highlightQuery,
-                            showDiacritics = config.showDiacritics,
-                            onClick = { config.onCommentClick(commentary) },
-                        )
-                    }
-                }
+    CommentatorsGrid(config = config) { commentatorId ->
+        val pagerFlow =
+            remember(lineIds, commentatorId) {
+                providers.buildCommentariesPagerForLines(lineIds, commentatorId)
             }
-        }
+        val initialIndex =
+            uiState.content.commentariesColumnScrollIndexByCommentator[commentatorId]
+                ?: uiState.content.commentariesScrollIndex
+        val initialOffset =
+            uiState.content.commentariesColumnScrollOffsetByCommentator[commentatorId]
+                ?: uiState.content.commentariesScrollOffset
+        CommentariesPagedList(
+            pagerFlow = pagerFlow,
+            initialIndex = initialIndex,
+            initialOffset = initialOffset,
+            onScroll = { i, o ->
+                onEvent(BookContentEvent.CommentaryColumnScrolled(commentatorId, i, o))
+            },
+            config = config,
+            restoreScrollKey = null,
+            showLoadingStates = false,
+            wrapInScrollableContainer = true,
+        )
     }
 }
 
@@ -673,7 +524,7 @@ private fun CommentatorsList(
 
 @Composable
 private fun CommentariesDisplay(
-    selectedCommentators: List<String>,
+    selectedCommentators: ImmutableList<String>,
     titleToIdMap: Map<String, Long>,
     selectedLineId: Long,
     uiState: BookContentState,
@@ -682,8 +533,6 @@ private fun CommentariesDisplay(
     findQueryText: String,
     showDiacritics: Boolean,
 ) {
-    val contentState = uiState.content
-
     if (selectedCommentators.isEmpty()) {
         CenteredMessage(
             message = stringResource(Res.string.select_at_least_one_commentator),
@@ -692,106 +541,81 @@ private fun CommentariesDisplay(
         return
     }
 
-    val windowInfo = LocalWindowInfo.current
-
-    // Memorizes the configuration to avoid recreating it
-    val commentaryFontCode by AppSettings.commentaryFontCodeFlow.collectAsState()
-    val commentaryFontFamily = FontCatalog.familyFor(commentaryFontCode)
-    val boldScaleForPlatform =
-        remember(commentaryFontCode) {
-            val lacksBold = commentaryFontCode in setOf("notoserifhebrew", "notorashihebrew", "frankruhllibre")
-            if (PlatformInfo.isMacOS && lacksBold) 1.08f else 1.0f
-        }
-
     val layoutConfig =
-        remember(
-            selectedCommentators,
-            titleToIdMap,
-            selectedLineId,
-            contentState.commentariesScrollIndex,
-            contentState.commentariesScrollOffset,
-            textSizes,
-            commentaryFontFamily,
-            boldScaleForPlatform,
-            findQueryText,
-            showDiacritics,
-        ) {
-            CommentariesLayoutConfig(
-                selectedCommentators = selectedCommentators,
-                titleToIdMap = titleToIdMap,
-                lineId = selectedLineId,
-                scrollIndex = contentState.commentariesScrollIndex,
-                scrollOffset = contentState.commentariesScrollOffset,
-                onScroll = { index, offset ->
-                    onEvent(BookContentEvent.CommentariesScrolled(index, offset))
-                },
-                onCommentClick = { commentary ->
-                    val mods = windowInfo.keyboardModifiers
-                    if (mods.isCtrlPressed || mods.isMetaPressed) {
-                        onEvent(
-                            BookContentEvent.OpenCommentaryTarget(
-                                bookId = commentary.link.targetBookId,
-                                lineId = commentary.link.targetLineId,
-                            ),
-                        )
-                    }
-                },
-                textSizes = textSizes,
-                fontFamily = commentaryFontFamily,
-                boldScale = boldScaleForPlatform,
-                highlightQuery = findQueryText,
-                showDiacritics = showDiacritics,
-            )
-        }
+        rememberCommentariesLayoutConfig(
+            selectedCommentators = selectedCommentators,
+            titleToIdMap = titleToIdMap,
+            textSizes = textSizes,
+            findQueryText = findQueryText,
+            showDiacritics = showDiacritics,
+            onEvent = onEvent,
+        )
 
-    CommentariesLayout(
-        layoutConfig = layoutConfig,
+    CommentatorsGridView(
+        config = layoutConfig,
+        lineId = selectedLineId,
         uiState = uiState,
         onEvent = onEvent,
     )
 }
 
 @Composable
-private fun CommentariesLayout(
-    layoutConfig: CommentariesLayoutConfig,
-    uiState: BookContentState,
-    onEvent: (BookContentEvent) -> Unit,
-) {
-    CommentatorsGridView(layoutConfig, uiState, onEvent)
-}
-
-@Composable
 private fun CommentatorsGridView(
     config: CommentariesLayoutConfig,
+    lineId: Long,
     uiState: BookContentState,
     onEvent: (BookContentEvent) -> Unit,
 ) {
-    // Cache the calculation of lines
+    val providers = uiState.providers ?: return
+    CommentatorsGrid(config = config) { commentatorId ->
+        val pagerFlow =
+            remember(lineId, commentatorId) {
+                providers.buildCommentariesPagerFor(lineId, commentatorId)
+            }
+        val initialIndex =
+            uiState.content.commentariesColumnScrollIndexByCommentator[commentatorId]
+                ?: uiState.content.commentariesScrollIndex
+        val initialOffset =
+            uiState.content.commentariesColumnScrollOffsetByCommentator[commentatorId]
+                ?: uiState.content.commentariesScrollOffset
+        CommentariesPagedList(
+            pagerFlow = pagerFlow,
+            initialIndex = initialIndex,
+            initialOffset = initialOffset,
+            onScroll = { i, o ->
+                onEvent(BookContentEvent.CommentaryColumnScrolled(commentatorId, i, o))
+            },
+            config = config,
+            restoreScrollKey = lineId to commentatorId,
+            showLoadingStates = true,
+            wrapInScrollableContainer = false,
+        )
+    }
+}
+
+/**
+ * Shared grid scaffolding for single-line and multi-line commentaries. The [column] slot
+ * renders one commentator column given its bookId.
+ */
+@Composable
+private fun CommentatorsGrid(
+    config: CommentariesLayoutConfig,
+    column: @Composable (commentatorId: Long) -> Unit,
+) {
     val rows =
         remember(config.selectedCommentators) {
             buildCommentatorRows(config.selectedCommentators)
         }
 
-    var primaryAssigned = false
-
     Column(modifier = Modifier.fillMaxSize()) {
-        rows.forEachIndexed { rowIndex, rowCommentators ->
+        rows.forEach { rowCommentators ->
             val rowModifier =
                 remember(rows.size) {
                     if (rows.size > 1) Modifier.weight(1f) else Modifier.fillMaxHeight()
                 }
             Row(modifier = rowModifier.fillMaxWidth()) {
-                rowCommentators.forEachIndexed { colIndex, name ->
-                    val id = config.titleToIdMap[name] ?: return@forEachIndexed
-                    val isPrimary =
-                        remember(primaryAssigned) {
-                            if (!primaryAssigned) {
-                                primaryAssigned = true
-                                true
-                            } else {
-                                false
-                            }
-                        }
+                rowCommentators.forEach { name ->
+                    val id = config.titleToIdMap[name] ?: return@forEach
                     val singleRowSingleCol = rows.size == 1 && rowCommentators.size == 1
                     val colModifier =
                         remember(singleRowSingleCol) {
@@ -803,23 +627,7 @@ private fun CommentatorsGridView(
                         }
                     Column(modifier = colModifier) {
                         CommentatorHeader(name, config.textSizes.commentTextSize)
-                        CommentaryListView(
-                            lineId = config.lineId,
-                            commentatorId = id,
-                            isPrimary = isPrimary,
-                            config = config,
-                            uiState = uiState,
-                            initialIndex =
-                                uiState.content.commentariesColumnScrollIndexByCommentator[id]
-                                    ?: uiState.content.commentariesScrollIndex,
-                            initialOffset =
-                                uiState.content.commentariesColumnScrollOffsetByCommentator[id]
-                                    ?: uiState.content.commentariesScrollOffset,
-                            onScroll = { i, o ->
-                                onEvent(BookContentEvent.CommentaryColumnScrolled(id, i, o))
-                            },
-                            highlightQuery = config.highlightQuery,
-                        )
+                        column(id)
                     }
                 }
             }
@@ -836,27 +644,23 @@ private fun buildCommentatorRows(selected: List<String>): List<List<String>> =
         else -> listOf(selected.subList(0, 2), selected.subList(2, minOf(4, selected.size)))
     }
 
+/**
+ * Paged list of [CommentaryItem]s for one commentator, wrapped in a [SafeSelectionContainer].
+ * Shared by single-line and multi-line views; asymmetric behaviors are gated behind flags.
+ */
 @OptIn(FlowPreview::class)
 @Composable
-private fun CommentaryListView(
-    lineId: Long,
-    commentatorId: Long,
-    isPrimary: Boolean,
-    config: CommentariesLayoutConfig,
-    uiState: BookContentState,
+private fun CommentariesPagedList(
+    pagerFlow: Flow<PagingData<CommentaryWithText>>,
     initialIndex: Int,
     initialOffset: Int,
     onScroll: (Int, Int) -> Unit,
-    highlightQuery: String,
+    config: CommentariesLayoutConfig,
+    restoreScrollKey: Any?,
+    showLoadingStates: Boolean,
+    wrapInScrollableContainer: Boolean,
 ) {
-    val providers = uiState.providers ?: return
     val currentOnScroll by rememberUpdatedState(onScroll)
-
-    val pagerFlow =
-        remember(lineId, commentatorId) {
-            providers.buildCommentariesPagerFor(lineId, commentatorId)
-        }
-
     val lazyPagingItems = pagerFlow.collectAsLazyPagingItems()
 
     val listState =
@@ -865,14 +669,16 @@ private fun CommentaryListView(
             initialFirstVisibleItemScrollOffset = initialOffset,
         )
 
-    var hasRestored by remember(lineId, commentatorId) { mutableStateOf(false) }
-    LaunchedEffect(lineId, commentatorId, lazyPagingItems.loadState.refresh, initialIndex, initialOffset) {
-        if (!hasRestored && lazyPagingItems.loadState.refresh !is LoadState.Loading) {
-            if (lazyPagingItems.itemCount > 0) {
-                val safeIndex = initialIndex.coerceIn(0, lazyPagingItems.itemCount - 1)
-                val safeOffset = initialOffset.coerceAtLeast(0)
-                listState.scrollToItem(safeIndex, safeOffset)
-                hasRestored = true
+    if (restoreScrollKey != null) {
+        var hasRestored by remember(restoreScrollKey) { mutableStateOf(false) }
+        LaunchedEffect(restoreScrollKey, lazyPagingItems.loadState.refresh, initialIndex, initialOffset) {
+            if (!hasRestored && lazyPagingItems.loadState.refresh !is LoadState.Loading) {
+                if (lazyPagingItems.itemCount > 0) {
+                    val safeIndex = initialIndex.coerceIn(0, lazyPagingItems.itemCount - 1)
+                    val safeOffset = initialOffset.coerceAtLeast(0)
+                    listState.scrollToItem(safeIndex, safeOffset)
+                    hasRestored = true
+                }
             }
         }
     }
@@ -881,46 +687,63 @@ private fun CommentaryListView(
         snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
             .distinctUntilChanged()
             .debounce(SCROLL_DEBOUNCE_MS)
-            .collect { (i, o) ->
-                currentOnScroll(i, o)
-            }
+            .collect { (i, o) -> currentOnScroll(i, o) }
     }
 
     SafeSelectionContainer(modifier = Modifier.fillMaxSize()) {
-        LazyColumn(
-            state = listState,
-            modifier = Modifier.fillMaxSize(),
-        ) {
-            items(
-                count = lazyPagingItems.itemCount,
-                key = { index -> lazyPagingItems[index]?.link?.id ?: index }, // Clé stable
-            ) { index ->
-                lazyPagingItems[index]?.let { commentary ->
-                    CommentaryItem(
-                        linkId = commentary.link.id,
-                        targetText = commentary.targetText,
-                        textSizes = config.textSizes,
-                        fontFamily = config.fontFamily,
-                        boldScale = config.boldScale,
-                        highlightQuery = highlightQuery,
-                        showDiacritics = config.showDiacritics,
-                        onClick = { config.onCommentClick(commentary) },
-                    )
-                }
+        if (wrapInScrollableContainer) {
+            VerticallyScrollableContainer(
+                scrollState = listState as ScrollableState,
+                scrollbarModifier = Modifier.fillMaxHeight(),
+            ) {
+                CommentariesLazyColumn(
+                    listState = listState,
+                    lazyPagingItems = lazyPagingItems,
+                    config = config,
+                    showLoadingStates = showLoadingStates,
+                )
             }
+        } else {
+            CommentariesLazyColumn(
+                listState = listState,
+                lazyPagingItems = lazyPagingItems,
+                config = config,
+                showLoadingStates = showLoadingStates,
+            )
+        }
+    }
+}
 
-            // Loading states
+@Composable
+private fun CommentariesLazyColumn(
+    listState: LazyListState,
+    lazyPagingItems: LazyPagingItems<CommentaryWithText>,
+    config: CommentariesLayoutConfig,
+    showLoadingStates: Boolean,
+) {
+    LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+        items(
+            count = lazyPagingItems.itemCount,
+            key = { index -> lazyPagingItems[index]?.link?.id ?: index },
+        ) { index ->
+            lazyPagingItems[index]?.let { commentary ->
+                CommentaryItem(
+                    linkId = commentary.link.id,
+                    targetText = commentary.targetText,
+                    textSizes = config.textSizes,
+                    fontFamily = config.fontFamily,
+                    boldScale = config.boldScale,
+                    highlightQuery = config.highlightQuery,
+                    showDiacritics = config.showDiacritics,
+                    onClick = { config.onCommentClick(commentary) },
+                )
+            }
+        }
+
+        if (showLoadingStates) {
             when (val loadState = lazyPagingItems.loadState.refresh) {
-                is LoadState.Loading -> {
-                    item { LoadingIndicator() }
-                }
-
-                is LoadState.Error -> {
-                    item {
-                        ErrorMessage(loadState.error)
-                    }
-                }
-
+                is LoadState.Loading -> item { LoadingIndicator() }
+                is LoadState.Error -> item { ErrorMessage(loadState.error) }
                 else -> {}
             }
         }
@@ -1235,12 +1058,8 @@ private data class AnimatedTextSizes(
 
 @Immutable
 private data class CommentariesLayoutConfig(
-    val selectedCommentators: List<String>,
+    val selectedCommentators: ImmutableList<String>,
     val titleToIdMap: Map<String, Long>,
-    val lineId: Long,
-    val scrollIndex: Int,
-    val scrollOffset: Int,
-    val onScroll: (Int, Int) -> Unit,
     val onCommentClick: (CommentaryWithText) -> Unit,
     val textSizes: AnimatedTextSizes,
     val fontFamily: FontFamily,
@@ -1248,6 +1067,56 @@ private data class CommentariesLayoutConfig(
     val highlightQuery: String,
     val showDiacritics: Boolean,
 )
+
+@Composable
+private fun rememberCommentariesLayoutConfig(
+    selectedCommentators: ImmutableList<String>,
+    titleToIdMap: Map<String, Long>,
+    textSizes: AnimatedTextSizes,
+    findQueryText: String,
+    showDiacritics: Boolean,
+    onEvent: (BookContentEvent) -> Unit,
+): CommentariesLayoutConfig {
+    val windowInfo = LocalWindowInfo.current
+    val commentaryFontCode by AppSettings.commentaryFontCodeFlow.collectAsState()
+    val commentaryFontFamily = FontCatalog.familyFor(commentaryFontCode)
+    val boldScaleForPlatform =
+        remember(commentaryFontCode) {
+            val lacksBold = commentaryFontCode in setOf("notoserifhebrew", "notorashihebrew", "frankruhllibre")
+            if (PlatformInfo.isMacOS && lacksBold) 1.08f else 1.0f
+        }
+
+    return remember(
+        selectedCommentators,
+        titleToIdMap,
+        textSizes,
+        commentaryFontFamily,
+        boldScaleForPlatform,
+        findQueryText,
+        showDiacritics,
+    ) {
+        CommentariesLayoutConfig(
+            selectedCommentators = selectedCommentators,
+            titleToIdMap = titleToIdMap,
+            onCommentClick = { commentary ->
+                val mods = windowInfo.keyboardModifiers
+                if (mods.isCtrlPressed || mods.isMetaPressed) {
+                    onEvent(
+                        BookContentEvent.OpenCommentaryTarget(
+                            bookId = commentary.link.targetBookId,
+                            lineId = commentary.link.targetLineId,
+                        ),
+                    )
+                }
+            },
+            textSizes = textSizes,
+            fontFamily = commentaryFontFamily,
+            boldScale = boldScaleForPlatform,
+            highlightQuery = findQueryText,
+            showDiacritics = showDiacritics,
+        )
+    }
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
@@ -435,7 +435,7 @@ private fun MultiLineCommentatorsGridView(
                 onEvent(BookContentEvent.CommentaryColumnScrolled(commentatorId, i, o))
             },
             config = config,
-            restoreScrollKey = null,
+            restoreScrollKey = lineIds to commentatorId,
             showLoadingStates = true,
             wrapInScrollableContainer = true,
         )

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
@@ -68,6 +68,7 @@ import org.jetbrains.compose.splitpane.rememberSplitPaneState
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.*
 import seforimapp.seforimapp.generated.resources.*
+import kotlin.time.Duration.Companion.milliseconds
 
 private const val MAX_COMMENTATORS = 4
 private const val SCROLL_DEBOUNCE_MS = 100L
@@ -459,7 +460,7 @@ private fun CommentatorsList(
         LaunchedEffect(listState) {
             snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
                 .distinctUntilChanged()
-                .debounce(SCROLL_DEBOUNCE_MS)
+                .debounce(SCROLL_DEBOUNCE_MS.milliseconds)
                 .collect { (i, o) -> currentOnScroll(i, o) }
         }
 
@@ -676,39 +677,34 @@ private fun CommentariesPagedList(
     LaunchedEffect(listState) {
         snapshotFlow { listState.firstVisibleItemIndex to listState.firstVisibleItemScrollOffset }
             .distinctUntilChanged()
-            .debounce(SCROLL_DEBOUNCE_MS)
+            .debounce(SCROLL_DEBOUNCE_MS.milliseconds)
             .collect { (i, o) -> currentOnScroll(i, o) }
     }
 
     SafeSelectionContainer(modifier = Modifier.fillMaxSize()) {
-        VerticallyScrollableContainer(
-            scrollState = listState as ScrollableState,
-            scrollbarModifier = Modifier.fillMaxHeight(),
-        ) {
-            LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
-                items(
-                    count = lazyPagingItems.itemCount,
-                    key = { index -> lazyPagingItems[index]?.link?.id ?: index },
-                ) { index ->
-                    lazyPagingItems[index]?.let { commentary ->
-                        CommentaryItem(
-                            linkId = commentary.link.id,
-                            targetText = commentary.targetText,
-                            textSizes = config.textSizes,
-                            fontFamily = config.fontFamily,
-                            boldScale = config.boldScale,
-                            highlightQuery = config.highlightQuery,
-                            showDiacritics = config.showDiacritics,
-                            onClick = { config.onCommentClick(commentary) },
-                        )
-                    }
+        LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+            items(
+                count = lazyPagingItems.itemCount,
+                key = { index -> lazyPagingItems[index]?.link?.id ?: index },
+            ) { index ->
+                lazyPagingItems[index]?.let { commentary ->
+                    CommentaryItem(
+                        linkId = commentary.link.id,
+                        targetText = commentary.targetText,
+                        textSizes = config.textSizes,
+                        fontFamily = config.fontFamily,
+                        boldScale = config.boldScale,
+                        highlightQuery = config.highlightQuery,
+                        showDiacritics = config.showDiacritics,
+                        onClick = { config.onCommentClick(commentary) },
+                    )
                 }
+            }
 
-                when (val loadState = lazyPagingItems.loadState.refresh) {
-                    is LoadState.Loading -> item { LoadingIndicator() }
-                    is LoadState.Error -> item { ErrorMessage(loadState.error) }
-                    else -> {}
-                }
+            when (val loadState = lazyPagingItems.loadState.refresh) {
+                is LoadState.Loading -> item { LoadingIndicator() }
+                is LoadState.Error -> item { ErrorMessage(loadState.error) }
+                else -> {}
             }
         }
     }


### PR DESCRIPTION
## Summary
- Collapse `CommentariesLayoutConfig` + `MultiLineCommentariesLayoutConfig` into one — the `lineId`/`lineIds`/`scrollIndex`/`scrollOffset`/`onScroll` fields were never read after construction.
- Replace `CommentaryListView` + `MultiLineCommentaryListView` with a single `CommentariesPagedList`.
- Extract `CommentatorsGrid` scaffolding shared by single-line and multi-line grids.
- Drop the unused `isPrimary` parameter.
- Level three accidental asymmetries between single-line and multi-line views (each in its own commit for bisecting):
  - scrollbar missing on single-line
  - loading/error indicators missing on multi-line
  - scroll restoration missing on multi-line

## Commits
1. \`refactor(commentaries): unify single/multi-line list into CommentariesPagedList\` — pure refactor, behavior preserved via flags
2. \`fix(commentaries): add scrollbar to single-line commentary column\` — asymmetry 1
3. \`fix(commentaries): show loading/error states in multi-line commentary column\` — asymmetry 2
4. \`fix(commentaries): restore scroll position in multi-line commentary column\` — asymmetry 3
5. \`refactor(commentaries): drop now-redundant CommentariesPagedList flags\` — flags are now always the same → inlined

Net: **~190 LOC removed**, one source of truth for rendering a commentary column.

## Test plan
- [x] Single-line view (default): scroll position survives navigating back to a previously visited line
- [x] Single-line view: Loading spinner shows on initial open, error message on failure
- [x] Single-line view: vertical scrollbar visible (new)
- [x] Multi-line view (Ctrl+click): scroll position now survives re-selecting the same combo (new)
- [x] Multi-line view: Loading spinner on initial aggregation, error on failure (new)
- [x] Multi-line view: vertical scrollbar still visible
- [x] Ctrl/Cmd+click on a commentary still opens the target in both modes