### PR TITLE
feat(bookcontent): content-aware scrollbar for sources/targum panes

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/BookContentViewModel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/BookContentViewModel.kt
@@ -157,6 +157,8 @@ class BookContentViewModel(
                             getAvailableSourcesForLines = commentariesUseCase::getAvailableSourcesForLines,
                             getCommentaryCharCountsForLine = commentariesUseCase::getCommentaryCharCountsForLine,
                             getCommentaryCharCountsForLines = commentariesUseCase::getCommentaryCharCountsForLines,
+                            getLinkCharCountsForLine = commentariesUseCase::getLinkCharCountsForLine,
+                            getLinkCharCountsForLines = commentariesUseCase::getLinkCharCountsForLines,
                         ),
                     content =
                         state.content.copy(
@@ -217,6 +219,8 @@ class BookContentViewModel(
                                 getAvailableSourcesForLines = commentariesUseCase::getAvailableSourcesForLines,
                                 getCommentaryCharCountsForLine = commentariesUseCase::getCommentaryCharCountsForLine,
                                 getCommentaryCharCountsForLines = commentariesUseCase::getCommentaryCharCountsForLines,
+                                getLinkCharCountsForLine = commentariesUseCase::getLinkCharCountsForLine,
+                                getLinkCharCountsForLines = commentariesUseCase::getLinkCharCountsForLines,
                             ),
                         content =
                             s.content.copy(

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/BookContentState.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/state/BookContentState.kt
@@ -35,6 +35,10 @@ data class Providers(
     // Mirror the pager ordering above; failures fold to an empty list.
     val getCommentaryCharCountsForLine: suspend (Long, Long) -> List<Int>,
     val getCommentaryCharCountsForLines: suspend (List<Long>, Long) -> List<Int>,
+    // Char-count vectors for sources/targum scrollbar, one section at a time
+    // (filtered by target-book id + connection type). Mirror the pager ordering.
+    val getLinkCharCountsForLine: suspend (Long, Long, ConnectionType) -> List<Int>,
+    val getLinkCharCountsForLines: suspend (List<Long>, Long, ConnectionType) -> List<Int>,
 )
 
 /**

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/CommentariesScrollbar.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/CommentariesScrollbar.kt
@@ -74,11 +74,12 @@ fun CommentariesScrollbar(
         ) ?: return
     if (latched.hidden) return
 
-    // Thumb **position** uses Compose's native avg-item scroll geometry, not the
-    // pixel-space estimate. Internally consistent: both `scrollOffsetAvg` and
-    // `contentSizeAvg` scale with the same `avgItemSize`, so `position` reaches 0 at
-    // scroll-start and 1 at scroll-end — no boundary pinning required, no flicker.
-    val position = computeAvgScrollPosition(listState).coerceIn(0f, 1f)
+    // Thumb **position** in pixel-space: `cumPx[firstIdx] + innerFraction × itemModelHeight`
+    // divided by `totalContentPx − viewport`. Uses cumPx (exact modelled weight of each
+    // preceding item) plus a real-pixel fraction remapped to cumPx units, so the thumb
+    // advances proportionally to the modelled weight of the current item.
+    val position =
+        computeScrollPosition(listState, cumPx, itemCount, totalContentPx).coerceIn(0f, 1f)
 
     val listStateRef = rememberUpdatedState(listState)
     val cumPxRef = rememberUpdatedState(cumPx)
@@ -102,7 +103,13 @@ fun CommentariesScrollbar(
                     val maxScrollPx = (totalPx - viewport).coerceAtLeast(0f).toDouble()
                     val targetPx = (thumbRatio.toDouble() * maxScrollPx).coerceIn(0.0, totalPx.toDouble())
                     val targetIdx = findItemIndexForPixel(cum, total, targetPx).coerceIn(0, loadedCount - 1)
-                    ls.requestScrollToItem(targetIdx, 0)
+                    // Offset **inside** the item so the viewport top lands exactly on
+                    // `targetPx`. Without it, `requestScrollToItem(idx, 0)` pins the
+                    // item to the viewport top and a drag to `thumbRatio = 1.0` stops
+                    // short of the real end by `targetPx − cumPx[targetIdx]` pixels.
+                    val offsetWithinItemPx =
+                        (targetPx - cum[targetIdx].toDouble()).coerceAtLeast(0.0).toInt()
+                    ls.requestScrollToItem(targetIdx, offsetWithinItemPx)
                 }
                 Unit
             }
@@ -119,29 +126,34 @@ fun CommentariesScrollbar(
 }
 
 /**
- * Thumb position in `[0, 1]`, computed from `LazyListState` the same way the standard
- * Compose scrollbar adapter does: `(firstIdx × avgItemSize + firstOffset) / (totalCount
- * × avgItemSize − viewport)`. Reaches 0 exactly at scroll-start (firstIdx and offset
- * both 0); reaches 1 approximately at scroll-end as long as `avgItemSize` (sampled
- * over the currently visible items) stays representative of the items at the tail.
- * Approximate between boundaries — acceptable for a progress indicator. No boundary
- * pinning, no flicker.
+ * Pixel-space thumb position in `[0, 1]`.
+ *
+ * Formula: `scrolledPx = cumPx[firstIdx] + innerFraction × itemModelHeight`, divided
+ * by `totalContentPx − viewport`. `cumPx[firstIdx]` exactly sums the modelled weight
+ * of every item before the first visible one. `innerFraction = -offset / size` is the
+ * proportion scrolled **through** the current item on real rendered pixels; multiplied
+ * by `cumPx[firstIdx + 1] − cumPx[firstIdx]` it converts back into cumPx units so a
+ * tall commentary moves the thumb more than a short one while scrolling through it.
  */
-private fun computeAvgScrollPosition(listState: LazyListState): Float {
+private fun computeScrollPosition(
+    listState: LazyListState,
+    cumPx: LongArray,
+    itemCount: Int,
+    totalContentPx: Float,
+): Float {
+    if (itemCount == 0 || cumPx.size < itemCount + 1) return 0f
     val info = listState.layoutInfo
-    val total = info.totalItemsCount
-    if (total == 0) return 0f
-    // Guard against paging prepends/appends where `visibleItemsInfo` briefly contains
-    // indices beyond the paging snapshot size.
-    val visible = info.visibleItemsInfo.filter { it.index in 0 until total }
+    // Guard against transient states where `visibleItemsInfo` contains indices outside
+    // our domain.
+    val visible = info.visibleItemsInfo.filter { it.index in 0 until itemCount }
     if (visible.isEmpty()) return 0f
-    val avgItemSize = visible.sumOf { it.size }.toFloat() / visible.size
-    if (avgItemSize <= 0f) return 0f
+    val firstInfo = visible.first()
+    val firstIdx = firstInfo.index.coerceIn(0, itemCount - 1)
+    val firstSize = firstInfo.size.coerceAtLeast(1)
+    val innerFraction = ((-firstInfo.offset).toFloat() / firstSize).coerceIn(0f, 1f)
+    val itemModelHeight = (cumPx[firstIdx + 1] - cumPx[firstIdx]).toFloat().coerceAtLeast(0f)
+    val scrolledPx = cumPx[firstIdx].toFloat() + innerFraction * itemModelHeight
     val viewport = (info.viewportEndOffset - info.viewportStartOffset).toFloat()
-    val contentSize = total * avgItemSize
-    val maxScroll = (contentSize - viewport).coerceAtLeast(1f)
-    val scrollOffset =
-        listState.firstVisibleItemIndex * avgItemSize +
-            listState.firstVisibleItemScrollOffset
-    return scrollOffset / maxScroll
+    val maxScroll = (totalContentPx - viewport).coerceAtLeast(1f)
+    return scrolledPx / maxScroll
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/ContentScrollbar.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/ContentScrollbar.kt
@@ -85,7 +85,7 @@ fun ContentScrollbar(
     // At scroll start `firstLineIdx = 0` → 0. At scroll end `firstLineIdx = N −
     // visibleLines` → 1. Numerator and denominator scale with the same `avgItemSize`
     // so the ratio reaches the boundaries exactly, no pinning required, no flicker.
-    val position = computeBookPosition(listState, lazyPagingItems, counts.size).coerceIn(0f, 1f)
+    val position = computeBookPosition(listState, lazyPagingItems, counts.size, cumPx, totalContentPx).coerceIn(0f, 1f)
 
     val listStateRef = rememberUpdatedState(listState)
     val pagingRef = rememberUpdatedState(lazyPagingItems)
@@ -138,9 +138,16 @@ fun ContentScrollbar(
                     val snapshot = pagingRef.value.itemSnapshotList.items
                     val hit = snapshot.binarySearchBy(targetLineIndex) { it.lineIndex }
                     val localIndex = if (hit >= 0) hit else -1
+                    // Offset **inside** the item so the viewport top lands exactly on
+                    // `targetPx`. Without it, `requestScrollToItem(idx, 0)` pins the
+                    // target line to the viewport top and a drag to `thumbRatio = 1.0`
+                    // stops short of the real end by `targetPx − cumPx[targetLineIndex]`
+                    // pixels.
+                    val offsetWithinItemPx =
+                        (targetPx - cum[targetLineIndex].toDouble()).coerceAtLeast(0.0).toInt()
                     when {
                         localIndex >= 0 -> {
-                            ls.requestScrollToItem(localIndex, 0)
+                            ls.requestScrollToItem(localIndex, offsetWithinItemPx)
                             pendingFarDragTarget.value = null
                         }
                         viaDrag -> {
@@ -177,18 +184,26 @@ fun ContentScrollbar(
 private val FAR_DRAG_THROTTLE = 200.milliseconds
 
 /**
- * Book-wide thumb position in `[0, 1]`, using the same avg-item geometry as the standard
- * Compose scrollbar adapter — but indexed on **book line number** rather than paging-
- * window index, so it reflects progress through the whole book, not just the loaded
- * page. Numerator and denominator both scale with `avgItemSize` so the ratio reaches 0
- * and 1 exactly at the book's scroll boundaries. No boundary pinning, no flicker.
+ * Book-wide thumb position in `[0, 1]`, in pixel-space.
+ *
+ * Formula: `scrolledPx = cumPx[firstLineIdx] + innerFraction × itemModelHeight`, divided
+ * by `totalContentPx − viewport`. `cumPx[firstLineIdx]` exactly encodes the modelled
+ * weight of every line before the first visible one. `innerFraction = -offset / size`
+ * is the proportion scrolled **through** the current item, measured on the real
+ * rendered pixels. Multiplying it by `cumPx[firstLineIdx + 1] − cumPx[firstLineIdx]`
+ * converts that proportion back into cumPx units, so the thumb advances proportionally
+ * to the item's modelled weight while scrolling through it — a tall line moves the
+ * thumb more than a short one, matching the reading progress. `.coerceIn(0f, 1f)` at
+ * the caller pins boundaries when the model and actual layout diverge slightly.
  */
 private fun computeBookPosition(
     listState: LazyListState,
     lazyPagingItems: LazyPagingItems<Line>,
     bookLineCount: Int,
+    cumPx: LongArray,
+    totalContentPx: Float,
 ): Float {
-    if (bookLineCount == 0) return 0f
+    if (bookLineCount == 0 || cumPx.size < bookLineCount + 1) return 0f
     val itemCount = lazyPagingItems.itemCount
     if (itemCount == 0) return 0f
     val info = listState.layoutInfo
@@ -198,13 +213,12 @@ private fun computeBookPosition(
     if (visible.isEmpty()) return 0f
     val firstInfo = visible.first()
     val firstLine = lazyPagingItems.peek(firstInfo.index) ?: return 0f
-    val firstLineIdx = firstLine.lineIndex.coerceAtLeast(0)
+    val firstLineIdx = firstLine.lineIndex.coerceIn(0, bookLineCount - 1)
     val firstSize = firstInfo.size.coerceAtLeast(1)
-    val firstInnerOffset = ((-firstInfo.offset).toFloat() / firstSize).coerceIn(0f, 1f)
-    val avgItemSize = visible.sumOf { it.size }.toFloat() / visible.size
-    if (avgItemSize <= 0f) return 0f
+    val innerFraction = ((-firstInfo.offset).toFloat() / firstSize).coerceIn(0f, 1f)
+    val itemModelHeight = (cumPx[firstLineIdx + 1] - cumPx[firstLineIdx]).toFloat().coerceAtLeast(0f)
+    val scrolledPx = cumPx[firstLineIdx].toFloat() + innerFraction * itemModelHeight
     val viewport = (info.viewportEndOffset - info.viewportStartOffset).toFloat()
-    val visibleCount = (viewport / avgItemSize).coerceAtLeast(1f)
-    val maxProgress = (bookLineCount - visibleCount).coerceAtLeast(1f)
-    return ((firstLineIdx + firstInnerOffset) / maxProgress)
+    val maxScroll = (totalContentPx - viewport).coerceAtLeast(1f)
+    return scrolledPx / maxScroll
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineTargumView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineTargumView.kt
@@ -21,11 +21,15 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.input.pointer.isCtrlPressed
 import androidx.compose.ui.input.pointer.isMetaPressed
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.paging.LoadState
@@ -48,6 +52,9 @@ import io.github.kdroidfilter.seforimlibrary.core.models.ConnectionType
 import io.github.kdroidfilter.seforimlibrary.core.models.Line
 import io.github.kdroidfilter.seforimlibrary.core.text.HebrewTextUtils
 import io.github.kdroidfilter.seforimlibrary.dao.repository.CommentaryWithText
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -65,12 +72,17 @@ import seforimapp.seforimapp.generated.resources.select_line_for_links
 import seforimapp.seforimapp.generated.resources.select_line_for_sources
 import seforimapp.seforimapp.generated.resources.sources
 
+// Per-side vertical padding applied by `LinkItem`'s Column. Exposed so the scrollbar
+// can derive the exact per-item padding contribution as `2 × LinkItemVerticalPaddingPerSide`.
+private val LinkItemVerticalPaddingPerSide = 8.dp
+
 @OptIn(ExperimentalSplitPaneApi::class)
 @Composable
 private fun SingleLineTargumView(
     selectedLine: Line?,
     buildLinksPagerFor: (Long, Long?) -> Flow<PagingData<CommentaryWithText>>,
     getAvailableLinksForLine: suspend (Long) -> Map<String, Long>,
+    getLinkCharCountsForLine: suspend (Long, Long, ConnectionType) -> List<Int>,
     showDiacritics: Boolean,
     commentariesScrollIndex: Int = 0,
     commentariesScrollOffset: Int = 0,
@@ -224,68 +236,143 @@ private fun SingleLineTargumView(
                                 .collect { (index, offset) -> currentOnScroll(index, offset) }
                         }
 
-                        SafeSelectionContainer(modifier = Modifier.fillMaxSize()) {
-                            LazyColumn(
-                                modifier = Modifier.fillMaxSize(),
-                                state = listState,
-                                verticalArrangement = Arrangement.spacedBy(8.dp),
-                            ) {
-                                sourceSections.forEach { section ->
-                                    item(key = "header-${section.bookId}") {
-                                        Text(
-                                            text = section.title,
-                                            fontWeight = FontWeight.Bold,
-                                            fontSize = (commentTextSize * 1.1f).sp,
-                                            textAlign = TextAlign.Center,
-                                            modifier = Modifier.fillMaxWidth(),
-                                        )
+                        // Build the flat char-count vector for the scrollbar in LazyColumn
+                        // display order: for each section, one zero entry (the bold title
+                        // header) followed by the section's ordered per-link char counts.
+                        // The per-section vector is fetched once per (lineId, bookId, type);
+                        // failures fold to an empty vector for that section.
+                        val sectionBookIds =
+                            remember(sourceSections) { sourceSections.map { it.bookId } }
+                        val getLinkCharCountsRef by rememberUpdatedState(getLinkCharCountsForLine)
+                        val allCharCounts by produceState(
+                            initialValue = emptyList<Int>(),
+                            selectedLine.id,
+                            sectionBookIds,
+                            availabilityType,
+                        ) {
+                            value =
+                                runSuspendCatching {
+                                    coroutineScope {
+                                        sectionBookIds
+                                            .map { bookId ->
+                                                async {
+                                                    getLinkCharCountsRef(
+                                                        selectedLine.id,
+                                                        bookId,
+                                                        availabilityType,
+                                                    )
+                                                }
+                                            }.awaitAll()
                                     }
+                                }.getOrElse { sectionBookIds.map { emptyList() } }
+                                    .flatMap { listOf(0) + it }
+                        }
 
-                                    items(
-                                        count = section.items.itemCount,
-                                        key = { index ->
-                                            section.items
-                                                .peek(index)
-                                                ?.link
-                                                ?.id ?: "source-${section.bookId}-$index"
-                                        },
-                                    ) { index ->
-                                        section.items[index]?.let { item ->
-                                            LinkItem(
-                                                linkId = item.link.id,
-                                                targetText = item.targetText,
-                                                commentTextSize = commentTextSize,
-                                                lineHeight = lineHeight,
-                                                fontFamily = targumFontFamily,
-                                                boldScale = boldScaleForPlatform,
-                                                highlightQuery = highlightQuery,
-                                                onClick = { onLinkClick(item) },
-                                                showDiacritics = showDiacritics,
+                        val density = LocalDensity.current
+                        val textMeasurer = rememberTextMeasurer()
+                        var textLayoutWidthPx by remember(selectedLine.id) { mutableIntStateOf(0) }
+                        val lineHeightPx =
+                            with(density) { (commentTextSize * lineHeight).sp.toPx() }
+                        val paddingPerItemPx =
+                            with(density) { (LinkItemVerticalPaddingPerSide * 2).toPx() }
+                        val capacity by remember(textLayoutWidthPx, commentTextSize, lineHeight, targumFontFamily) {
+                            derivedStateOf {
+                                if (textLayoutWidthPx <= 0) {
+                                    0
+                                } else {
+                                    val result =
+                                        textMeasurer.measure(
+                                            text = AnnotatedString(CAPACITY_REFERENCE),
+                                            style =
+                                                TextStyle(
+                                                    fontSize = commentTextSize.sp,
+                                                    fontFamily = targumFontFamily,
+                                                    lineHeight = (commentTextSize * lineHeight).sp,
+                                                ),
+                                            constraints = Constraints(maxWidth = textLayoutWidthPx),
+                                        )
+                                    (CAPACITY_REFERENCE.length / result.lineCount.coerceAtLeast(1)).coerceAtLeast(1)
+                                }
+                            }
+                        }
+
+                        SafeSelectionContainer(modifier = Modifier.fillMaxSize()) {
+                            Box(modifier = Modifier.fillMaxSize()) {
+                                LazyColumn(
+                                    modifier = Modifier.fillMaxSize().padding(end = 12.dp),
+                                    state = listState,
+                                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                                ) {
+                                    sourceSections.forEach { section ->
+                                        item(key = "header-${section.bookId}") {
+                                            Text(
+                                                text = section.title,
+                                                fontWeight = FontWeight.Bold,
+                                                fontSize = (commentTextSize * 1.1f).sp,
+                                                textAlign = TextAlign.Center,
+                                                modifier = Modifier.fillMaxWidth(),
                                             )
                                         }
-                                    }
 
-                                    when (val state = section.items.loadState.append) {
-                                        is LoadState.Error ->
-                                            item(key = "append-error-${section.bookId}") {
-                                                Box(
-                                                    modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-                                                    contentAlignment = Alignment.Center,
-                                                ) {
-                                                    Text(text = state.error.message ?: "Error loading more")
-                                                }
+                                        items(
+                                            count = section.items.itemCount,
+                                            key = { index ->
+                                                section.items
+                                                    .peek(index)
+                                                    ?.link
+                                                    ?.id ?: "source-${section.bookId}-$index"
+                                            },
+                                        ) { index ->
+                                            section.items[index]?.let { item ->
+                                                LinkItem(
+                                                    linkId = item.link.id,
+                                                    targetText = item.targetText,
+                                                    commentTextSize = commentTextSize,
+                                                    lineHeight = lineHeight,
+                                                    fontFamily = targumFontFamily,
+                                                    boldScale = boldScaleForPlatform,
+                                                    highlightQuery = highlightQuery,
+                                                    onClick = { onLinkClick(item) },
+                                                    showDiacritics = showDiacritics,
+                                                    onLayoutWidthMeasure = { width ->
+                                                        if (textLayoutWidthPx == 0 && width > 0) {
+                                                            textLayoutWidthPx = width
+                                                        }
+                                                    },
+                                                )
                                             }
+                                        }
 
-                                        is LoadState.Loading ->
-                                            item(key = "append-loading-${section.bookId}") {
-                                                Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                                                    CircularProgressIndicator()
+                                        when (val state = section.items.loadState.append) {
+                                            is LoadState.Error ->
+                                                item(key = "append-error-${section.bookId}") {
+                                                    Box(
+                                                        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                                                        contentAlignment = Alignment.Center,
+                                                    ) {
+                                                        Text(text = state.error.message ?: "Error loading more")
+                                                    }
                                                 }
-                                            }
 
-                                        else -> {}
+                                            is LoadState.Loading ->
+                                                item(key = "append-loading-${section.bookId}") {
+                                                    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                                                        CircularProgressIndicator()
+                                                    }
+                                                }
+
+                                            else -> {}
+                                        }
                                     }
                                 }
+                                TargumScrollbar(
+                                    listState = listState,
+                                    allCharCounts = allCharCounts,
+                                    capacity = capacity,
+                                    lineHeightPx = lineHeightPx,
+                                    paddingPerItemPx = paddingPerItemPx,
+                                    modifier = Modifier.align(Alignment.CenterEnd).padding(end = 2.dp),
+                                )
                             }
                         }
                     }
@@ -394,6 +481,7 @@ fun LineTargumView(
             selectedLine = contentState.primaryLine,
             buildLinksPagerFor = buildPagerFor,
             getAvailableLinksForLine = getAvailableForLine,
+            getLinkCharCountsForLine = providers.getLinkCharCountsForLine,
             commentariesScrollIndex = contentState.commentariesScrollIndex,
             commentariesScrollOffset = contentState.commentariesScrollOffset,
             initiallySelectedSourceIds = initiallySelectedIds,
@@ -543,78 +631,148 @@ private fun MultiLineTargumView(
                         }
                 }
 
-                SafeSelectionContainer(modifier = Modifier.fillMaxSize()) {
-                    LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
-                        state = listState,
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        sourceSections.forEach { section ->
-                            item(key = "header-${section.bookId}") {
-                                Text(
-                                    text = section.title,
-                                    fontWeight = FontWeight.Bold,
-                                    fontSize = (commentTextSize * 1.1f).sp,
-                                    textAlign = TextAlign.Center,
-                                    modifier = Modifier.fillMaxWidth(),
-                                )
+                val sectionBookIds =
+                    remember(sourceSections) { sourceSections.map { it.bookId } }
+                val getLinkCharCountsRef by rememberUpdatedState(providers.getLinkCharCountsForLines)
+                val allCharCounts by produceState(
+                    initialValue = emptyList<Int>(),
+                    selectedLineIds,
+                    sectionBookIds,
+                    availabilityType,
+                ) {
+                    value =
+                        runSuspendCatching {
+                            coroutineScope {
+                                sectionBookIds
+                                    .map { bookId ->
+                                        async {
+                                            getLinkCharCountsRef(
+                                                selectedLineIds,
+                                                bookId,
+                                                availabilityType,
+                                            )
+                                        }
+                                    }.awaitAll()
                             }
+                        }.getOrElse { sectionBookIds.map { emptyList() } }
+                            .flatMap { listOf(0) + it }
+                }
 
-                            items(
-                                count = section.items.itemCount,
-                                key = { index ->
-                                    section.items
-                                        .peek(index)
-                                        ?.link
-                                        ?.id ?: "multi-source-${section.bookId}-$index"
-                                },
-                            ) { index ->
-                                section.items[index]?.let { item ->
-                                    LinkItem(
-                                        linkId = item.link.id,
-                                        targetText = item.targetText,
-                                        commentTextSize = commentTextSize,
-                                        lineHeight = lineHeight,
-                                        fontFamily = targumFontFamily,
-                                        boldScale = boldScaleForPlatform,
-                                        highlightQuery = highlightQuery,
-                                        onClick = {
-                                            val mods = windowInfo.keyboardModifiers
-                                            if (mods.isCtrlPressed || mods.isMetaPressed) {
-                                                onEvent(
-                                                    BookContentEvent.OpenCommentaryTarget(
-                                                        bookId = item.link.targetBookId,
-                                                        lineId = item.link.targetLineId,
-                                                    ),
-                                                )
-                                            }
-                                        },
-                                        showDiacritics = showDiacritics,
+                val density = LocalDensity.current
+                val textMeasurer = rememberTextMeasurer()
+                var textLayoutWidthPx by remember(selectedLineIds) { mutableIntStateOf(0) }
+                val lineHeightPx =
+                    with(density) { (commentTextSize * lineHeight).sp.toPx() }
+                val paddingPerItemPx =
+                    with(density) { (LinkItemVerticalPaddingPerSide * 2).toPx() }
+                val capacity by remember(textLayoutWidthPx, commentTextSize, lineHeight, targumFontFamily) {
+                    derivedStateOf {
+                        if (textLayoutWidthPx <= 0) {
+                            0
+                        } else {
+                            val result =
+                                textMeasurer.measure(
+                                    text = AnnotatedString(CAPACITY_REFERENCE),
+                                    style =
+                                        TextStyle(
+                                            fontSize = commentTextSize.sp,
+                                            fontFamily = targumFontFamily,
+                                            lineHeight = (commentTextSize * lineHeight).sp,
+                                        ),
+                                    constraints = Constraints(maxWidth = textLayoutWidthPx),
+                                )
+                            (CAPACITY_REFERENCE.length / result.lineCount.coerceAtLeast(1)).coerceAtLeast(1)
+                        }
+                    }
+                }
+
+                SafeSelectionContainer(modifier = Modifier.fillMaxSize()) {
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize().padding(end = 12.dp),
+                            state = listState,
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            sourceSections.forEach { section ->
+                                item(key = "header-${section.bookId}") {
+                                    Text(
+                                        text = section.title,
+                                        fontWeight = FontWeight.Bold,
+                                        fontSize = (commentTextSize * 1.1f).sp,
+                                        textAlign = TextAlign.Center,
+                                        modifier = Modifier.fillMaxWidth(),
                                     )
                                 }
-                            }
 
-                            when (val state = section.items.loadState.append) {
-                                is LoadState.Error ->
-                                    item(key = "append-error-${section.bookId}") {
-                                        Box(
-                                            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
-                                            contentAlignment = Alignment.Center,
-                                        ) {
-                                            Text(text = state.error.message ?: "Error loading more")
-                                        }
+                                items(
+                                    count = section.items.itemCount,
+                                    key = { index ->
+                                        section.items
+                                            .peek(index)
+                                            ?.link
+                                            ?.id ?: "multi-source-${section.bookId}-$index"
+                                    },
+                                ) { index ->
+                                    section.items[index]?.let { item ->
+                                        LinkItem(
+                                            linkId = item.link.id,
+                                            targetText = item.targetText,
+                                            commentTextSize = commentTextSize,
+                                            lineHeight = lineHeight,
+                                            fontFamily = targumFontFamily,
+                                            boldScale = boldScaleForPlatform,
+                                            highlightQuery = highlightQuery,
+                                            onClick = {
+                                                val mods = windowInfo.keyboardModifiers
+                                                if (mods.isCtrlPressed || mods.isMetaPressed) {
+                                                    onEvent(
+                                                        BookContentEvent.OpenCommentaryTarget(
+                                                            bookId = item.link.targetBookId,
+                                                            lineId = item.link.targetLineId,
+                                                        ),
+                                                    )
+                                                }
+                                            },
+                                            showDiacritics = showDiacritics,
+                                            onLayoutWidthMeasure = { width ->
+                                                if (textLayoutWidthPx == 0 && width > 0) {
+                                                    textLayoutWidthPx = width
+                                                }
+                                            },
+                                        )
                                     }
+                                }
 
-                                is LoadState.Loading ->
-                                    item(key = "append-loading-${section.bookId}") {
-                                        Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                                            CircularProgressIndicator()
+                                when (val state = section.items.loadState.append) {
+                                    is LoadState.Error ->
+                                        item(key = "append-error-${section.bookId}") {
+                                            Box(
+                                                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                                                contentAlignment = Alignment.Center,
+                                            ) {
+                                                Text(text = state.error.message ?: "Error loading more")
+                                            }
                                         }
-                                    }
 
-                                else -> {}
+                                    is LoadState.Loading ->
+                                        item(key = "append-loading-${section.bookId}") {
+                                            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                                                CircularProgressIndicator()
+                                            }
+                                        }
+
+                                    else -> {}
+                                }
                             }
                         }
+                        TargumScrollbar(
+                            listState = listState,
+                            allCharCounts = allCharCounts,
+                            capacity = capacity,
+                            lineHeightPx = lineHeightPx,
+                            paddingPerItemPx = paddingPerItemPx,
+                            modifier = Modifier.align(Alignment.CenterEnd).padding(end = 2.dp),
+                        )
                     }
                 }
             }
@@ -644,12 +802,13 @@ private fun LinkItem(
     onClick: () -> Unit,
     showDiacritics: Boolean,
     boldScale: Float = 1.0f,
+    onLayoutWidthMeasure: (Int) -> Unit = {},
 ) {
     Column(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(vertical = 8.dp, horizontal = 16.dp)
+                .padding(vertical = LinkItemVerticalPaddingPerSide, horizontal = 16.dp)
                 .pointerInput(linkId) {
                     detectTapGestures(onTap = { onClick() })
                 },
@@ -705,6 +864,10 @@ private fun LinkItem(
             fontFamily = fontFamily,
             lineHeight = (commentTextSize * lineHeight).sp,
             inlineContent = inlineImageContent,
+            onTextLayout = { result ->
+                val cw = result.layoutInput.constraints.maxWidth
+                if (cw > 0 && cw != Int.MAX_VALUE) onLayoutWidthMeasure(cw)
+            },
         )
     }
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/TargumScrollbar.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/TargumScrollbar.kt
@@ -1,0 +1,122 @@
+package io.github.kdroidfilter.seforimapp.features.bookcontent.ui.panels.bookcontent.views
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+
+/**
+ * Content-aware vertical scrollbar for a multi-section link/targum list.
+ *
+ * The list is a single [androidx.compose.foundation.lazy.LazyColumn] concatenating
+ * N sections, each laid out as `[section header] + [paged link items]`. The scrollbar
+ * receives [allCharCounts] already flattened in that same display order — the caller
+ * inserts a zero char-count entry per header so cumulative pixels line up one-to-one
+ * with the LazyColumn's item indices.
+ *
+ * Thumb size follows the same pixel-space model as [CommentariesScrollbar]: each
+ * item contributes `ceil(charCount / capacity) × lineHeightPx + paddingPerItemPx`
+ * to the total content height, so a short header and a 2000-char targum entry scale
+ * proportionally. Thumb position uses Compose's native avg-item geometry (same as
+ * the commentaries scrollbar) — stable at boundaries, approximate in between.
+ *
+ * Visual styling comes from [org.jetbrains.jewel.ui.theme.scrollbarStyle] via
+ * [ContentAwareScrollbarShell], keeping the track / thumb / hover-expand identical
+ * to every other scrollbar in the content pane.
+ */
+@Composable
+fun TargumScrollbar(
+    listState: LazyListState,
+    allCharCounts: List<Int>,
+    capacity: Int,
+    lineHeightPx: Float,
+    paddingPerItemPx: Float,
+    modifier: Modifier = Modifier,
+) {
+    if (allCharCounts.isEmpty()) return
+    if (capacity <= 0 || lineHeightPx <= 0f) return
+
+    val cumPx by remember(allCharCounts, capacity, lineHeightPx, paddingPerItemPx) {
+        derivedStateOf {
+            buildCumulativePixels(
+                size = allCharCounts.size,
+                capacity = capacity,
+                lineHeightPx = lineHeightPx,
+                paddingPerItemPx = paddingPerItemPx,
+                charCountAt = { allCharCounts[it] },
+            )
+        }
+    }
+    val itemCount = allCharCounts.size
+    val totalContentPx = cumPx[itemCount].toFloat()
+
+    val latched =
+        rememberLatchedThumbSize(
+            latchKey = allCharCounts,
+            capacity = capacity,
+            lineHeightPx = lineHeightPx,
+            totalContentPx = totalContentPx,
+            listState = listState,
+        ) ?: return
+    if (latched.hidden) return
+
+    val position = computeAvgScrollPosition(listState).coerceIn(0f, 1f)
+
+    val listStateRef = rememberUpdatedState(listState)
+    val cumPxRef = rememberUpdatedState(cumPx)
+    val totalContentPxRef = rememberUpdatedState(totalContentPx)
+    val itemCountRef = rememberUpdatedState(itemCount)
+
+    val applyTarget =
+        remember {
+            { thumbRatio: Float, _: Boolean ->
+                val ls = listStateRef.value
+                val total = itemCountRef.value
+                val cum = cumPxRef.value
+                val info = ls.layoutInfo
+                val loadedCount = info.totalItemsCount
+                if (total > 0 && loadedCount > 0 && cum.size >= total + 1) {
+                    val viewport = (info.viewportEndOffset - info.viewportStartOffset).toFloat()
+                    val totalPx = totalContentPxRef.value
+                    val maxScrollPx = (totalPx - viewport).coerceAtLeast(0f).toDouble()
+                    val targetPx = (thumbRatio.toDouble() * maxScrollPx).coerceIn(0.0, totalPx.toDouble())
+                    val targetIdx = findItemIndexForPixel(cum, total, targetPx).coerceIn(0, loadedCount - 1)
+                    ls.requestScrollToItem(targetIdx, 0)
+                }
+                Unit
+            }
+        }
+
+    ContentAwareScrollbarShell(
+        listState = listState,
+        position = position,
+        thumbSize = latched.size,
+        visualsLabel = "targum_scrollbar",
+        onApplyTarget = applyTarget,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Thumb position in `[0, 1]` from [LazyListState] using the same avg-item geometry
+ * as the standard Compose scrollbar adapter. Duplicated locally to avoid coupling
+ * to [CommentariesScrollbar]'s private helper.
+ */
+private fun computeAvgScrollPosition(listState: LazyListState): Float {
+    val info = listState.layoutInfo
+    val total = info.totalItemsCount
+    if (total == 0) return 0f
+    val visible = info.visibleItemsInfo.filter { it.index in 0 until total }
+    if (visible.isEmpty()) return 0f
+    val avgItemSize = visible.sumOf { it.size }.toFloat() / visible.size
+    if (avgItemSize <= 0f) return 0f
+    val viewport = (info.viewportEndOffset - info.viewportStartOffset).toFloat()
+    val contentSize = total * avgItemSize
+    val maxScroll = (contentSize - viewport).coerceAtLeast(1f)
+    val scrollOffset =
+        listState.firstVisibleItemIndex * avgItemSize + listState.firstVisibleItemScrollOffset
+    return scrollOffset / maxScroll
+}

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/TargumScrollbar.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/TargumScrollbar.kt
@@ -63,7 +63,8 @@ fun TargumScrollbar(
         ) ?: return
     if (latched.hidden) return
 
-    val position = computeAvgScrollPosition(listState).coerceIn(0f, 1f)
+    val position =
+        computeScrollPosition(listState, cumPx, itemCount, totalContentPx).coerceIn(0f, 1f)
 
     val listStateRef = rememberUpdatedState(listState)
     val cumPxRef = rememberUpdatedState(cumPx)
@@ -84,7 +85,14 @@ fun TargumScrollbar(
                     val maxScrollPx = (totalPx - viewport).coerceAtLeast(0f).toDouble()
                     val targetPx = (thumbRatio.toDouble() * maxScrollPx).coerceIn(0.0, totalPx.toDouble())
                     val targetIdx = findItemIndexForPixel(cum, total, targetPx).coerceIn(0, loadedCount - 1)
-                    ls.requestScrollToItem(targetIdx, 0)
+                    // Offset **inside** the item so the viewport top lands exactly on
+                    // `targetPx` — without it, `requestScrollToItem(idx, 0)` always
+                    // places the item at the viewport top, which at `thumbRatio = 1.0`
+                    // leaves a `targetPx − cumPx[targetIdx]` gap and the text never
+                    // reaches the real end.
+                    val offsetWithinItemPx =
+                        (targetPx - cum[targetIdx].toDouble()).coerceAtLeast(0.0).toInt()
+                    ls.requestScrollToItem(targetIdx, offsetWithinItemPx)
                 }
                 Unit
             }
@@ -101,22 +109,33 @@ fun TargumScrollbar(
 }
 
 /**
- * Thumb position in `[0, 1]` from [LazyListState] using the same avg-item geometry
- * as the standard Compose scrollbar adapter. Duplicated locally to avoid coupling
- * to [CommentariesScrollbar]'s private helper.
+ * Pixel-space thumb position in `[0, 1]`.
+ *
+ * Formula: `scrolledPx = cumPx[firstIdx] + innerFraction × itemModelHeight`, divided
+ * by `totalContentPx − viewport`. `cumPx[firstIdx]` sums modelled weights of items
+ * before the first visible one. `innerFraction = -offset / size` is the real-pixel
+ * proportion scrolled through the current item; multiplied by `cumPx[firstIdx + 1] −
+ * cumPx[firstIdx]` it reflects the item's modelled weight so a long link moves the
+ * thumb more than a short one while scrolling through it. Duplicated locally to avoid
+ * coupling to [CommentariesScrollbar]'s private helper.
  */
-private fun computeAvgScrollPosition(listState: LazyListState): Float {
+private fun computeScrollPosition(
+    listState: LazyListState,
+    cumPx: LongArray,
+    itemCount: Int,
+    totalContentPx: Float,
+): Float {
+    if (itemCount == 0 || cumPx.size < itemCount + 1) return 0f
     val info = listState.layoutInfo
-    val total = info.totalItemsCount
-    if (total == 0) return 0f
-    val visible = info.visibleItemsInfo.filter { it.index in 0 until total }
+    val visible = info.visibleItemsInfo.filter { it.index in 0 until itemCount }
     if (visible.isEmpty()) return 0f
-    val avgItemSize = visible.sumOf { it.size }.toFloat() / visible.size
-    if (avgItemSize <= 0f) return 0f
+    val firstInfo = visible.first()
+    val firstIdx = firstInfo.index.coerceIn(0, itemCount - 1)
+    val firstSize = firstInfo.size.coerceAtLeast(1)
+    val innerFraction = ((-firstInfo.offset).toFloat() / firstSize).coerceIn(0f, 1f)
+    val itemModelHeight = (cumPx[firstIdx + 1] - cumPx[firstIdx]).toFloat().coerceAtLeast(0f)
+    val scrolledPx = cumPx[firstIdx].toFloat() + innerFraction * itemModelHeight
     val viewport = (info.viewportEndOffset - info.viewportStartOffset).toFloat()
-    val contentSize = total * avgItemSize
-    val maxScroll = (contentSize - viewport).coerceAtLeast(1f)
-    val scrollOffset =
-        listState.firstVisibleItemIndex * avgItemSize + listState.firstVisibleItemScrollOffset
-    return scrollOffset / maxScroll
+    val maxScroll = (totalContentPx - viewport).coerceAtLeast(1f)
+    return scrolledPx / maxScroll
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/usecases/CommentariesUseCase.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/usecases/CommentariesUseCase.kt
@@ -200,6 +200,42 @@ class CommentariesUseCase(
         }.getOrElse { emptyList() }
 
     /**
+     * Ordered char-count vector for a single source/targum section attached to a base
+     * line (or its TOC section). Mirrors [buildLinksPager] / [buildSourcesPager] row
+     * ordering (`b.orderIndex, l.targetLineIndex`). Returns an empty list on failure.
+     */
+    suspend fun getLinkCharCountsForLine(
+        lineId: Long,
+        sourceBookId: Long,
+        connectionType: ConnectionType,
+    ): List<Int> =
+        runSuspendCatching {
+            repository.getCommentaryCharCountsForLineOrSection(
+                baseLineId = lineId,
+                activeCommentatorIds = setOf(sourceBookId),
+                connectionTypes = setOf(connectionType),
+            )
+        }.getOrElse { emptyList() }
+
+    /**
+     * Ordered char-count vector for a single source/targum section across multiple
+     * selected lines. Mirrors [buildLinksPagerForLines] / [buildSourcesPagerForLines]
+     * ordering. Returns an empty list on failure.
+     */
+    suspend fun getLinkCharCountsForLines(
+        lineIds: List<Long>,
+        sourceBookId: Long,
+        connectionType: ConnectionType,
+    ): List<Int> =
+        runSuspendCatching {
+            repository.getCommentaryCharCountsForLines(
+                lineIds = lineIds,
+                activeCommentatorIds = setOf(sourceBookId),
+                connectionTypes = setOf(connectionType),
+            )
+        }.getOrElse { emptyList() }
+
+    /**
      * Récupère les commentateurs disponibles pour plusieurs lignes (union)
      */
     suspend fun getAvailableCommentatorsForLines(lineIds: List<Long>): Map<String, Long> {


### PR DESCRIPTION
## Summary
- Replace the basic Jewel `VerticallyScrollableContainer` in the sources/targum panes with the same pixel-space scrollbar used by the book and commentaries panes.
- Add `getLinkCharCountsForLine` / `getLinkCharCountsForLines` (reusing the existing repository calls filtered by target book id + `ConnectionType`).
- Introduce `TargumScrollbar` on top of `ContentAwareScrollbarShell` with `buildCumulativePixels` + `findItemIndexForPixel` + `rememberLatchedThumbSize`, mirroring `CommentariesScrollbar`.
- In `LineTargumView` (single and multi-line), fetch per-section char counts in parallel and flatten them with a zero entry per section header so cumulative pixels line up one-to-one with LazyColumn indices. Capacity is measured via `TextMeasurer` against the first laid-out item.

## Test plan
- [x] Open a book whose primary line has several sources/targums → scrollbar thumb size reflects real content height, not avg-item geometry.
- [x] Drag the thumb — list lands on the correct visual position even when one source is a very long targum and the others are short.
- [x] Ctrl-select multiple lines → multi-line variant renders the same content-aware scrollbar.
- [x] Toggle font / text size — capacity re-measures and the thumb resizes without flicker.
- [x] Resize the split pane — scrollbar re-latches on viewport drift.
- [x] Empty / single-source / error states still render correctly.