### PR TITLE
perf: persistent SQLite driver + scrollbar micro-opts

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/CommentariesScrollbar.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/CommentariesScrollbar.kt
@@ -144,10 +144,17 @@ private fun computeScrollPosition(
     if (itemCount == 0 || cumPx.size < itemCount + 1) return 0f
     val info = listState.layoutInfo
     // Guard against transient states where `visibleItemsInfo` contains indices outside
-    // our domain.
-    val visible = info.visibleItemsInfo.filter { it.index in 0 until itemCount }
-    if (visible.isEmpty()) return 0f
-    val firstInfo = visible.first()
+    // our domain. Single-pass scan avoids a List allocation per scroll frame (60 Hz).
+    var firstInfo: androidx.compose.foundation.lazy.LazyListItemInfo? = null
+    val visibleList = info.visibleItemsInfo
+    for (i in visibleList.indices) {
+        val item = visibleList[i]
+        if (item.index in 0 until itemCount) {
+            firstInfo = item
+            break
+        }
+    }
+    if (firstInfo == null) return 0f
     val firstIdx = firstInfo.index.coerceIn(0, itemCount - 1)
     val firstSize = firstInfo.size.coerceAtLeast(1)
     val innerFraction = ((-firstInfo.offset).toFloat() / firstSize).coerceIn(0f, 1f)

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/ContentAwareScrollbarShell.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/ContentAwareScrollbarShell.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.firstOrNull
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.styling.ScrollbarVisibility.AlwaysVisible
 import org.jetbrains.jewel.ui.theme.scrollbarStyle
@@ -217,15 +218,21 @@ internal fun ContentAwareScrollbarShell(
 
     val travelPxState = rememberUpdatedState(travelPx)
     val displayPositionState = rememberUpdatedState(displayPosition)
+    val positionState = rememberUpdatedState(position)
     val onApplyTargetState = rememberUpdatedState(onApplyTarget)
     val onDragStartState = rememberUpdatedState(onDragStart)
     val onDragStopState = rememberUpdatedState(onDragStop)
 
-    // Convergence: unpin the thumb once the live scroll catches up to the dragged target.
-    LaunchedEffect(dragRatio, isDragging, position) {
+    // Convergence: while a drag target is pinned, observe `position` via `snapshotFlow`
+    // and unpin the thumb as soon as the live scroll catches up. Keyed only on
+    // `dragRatio` / `isDragging` so the effect doesn't churn on every scroll frame —
+    // `positionState` feeds the collector through Compose's snapshot system instead.
+    LaunchedEffect(dragRatio, isDragging) {
         val target = dragRatio ?: return@LaunchedEffect
         if (isDragging) return@LaunchedEffect
-        if (abs(position - target) <= 0.005f) dragRatio = null
+        snapshotFlow { positionState.value }
+            .firstOrNull { abs(it - target) <= 0.005f }
+            ?.let { dragRatio = null }
     }
     LaunchedEffect(dragRatio, isDragging) {
         if (isDragging || dragRatio == null) return@LaunchedEffect

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/ContentScrollbar.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/ContentScrollbar.kt
@@ -209,9 +209,17 @@ private fun computeBookPosition(
     val info = listState.layoutInfo
     // Guard against paging prepends/appends where `visibleItemsInfo` briefly contains
     // indices beyond the snapshot size — `peek()` would throw `IndexOutOfBoundsException`.
-    val visible = info.visibleItemsInfo.filter { it.index in 0 until itemCount }
-    if (visible.isEmpty()) return 0f
-    val firstInfo = visible.first()
+    // Single-pass scan to avoid allocating a filtered list on every scroll frame (60 Hz).
+    var firstInfo: androidx.compose.foundation.lazy.LazyListItemInfo? = null
+    val visibleList = info.visibleItemsInfo
+    for (i in visibleList.indices) {
+        val item = visibleList[i]
+        if (item.index in 0 until itemCount) {
+            firstInfo = item
+            break
+        }
+    }
+    if (firstInfo == null) return 0f
     val firstLine = lazyPagingItems.peek(firstInfo.index) ?: return 0f
     val firstLineIdx = firstLine.lineIndex.coerceIn(0, bookLineCount - 1)
     val firstSize = firstInfo.size.coerceAtLeast(1)

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/TargumScrollbar.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/TargumScrollbar.kt
@@ -127,9 +127,17 @@ private fun computeScrollPosition(
 ): Float {
     if (itemCount == 0 || cumPx.size < itemCount + 1) return 0f
     val info = listState.layoutInfo
-    val visible = info.visibleItemsInfo.filter { it.index in 0 until itemCount }
-    if (visible.isEmpty()) return 0f
-    val firstInfo = visible.first()
+    // Single-pass scan avoids a List allocation per scroll frame (60 Hz).
+    var firstInfo: androidx.compose.foundation.lazy.LazyListItemInfo? = null
+    val visibleList = info.visibleItemsInfo
+    for (i in visibleList.indices) {
+        val item = visibleList[i]
+        if (item.index in 0 until itemCount) {
+            firstInfo = item
+            break
+        }
+    }
+    if (firstInfo == null) return 0f
     val firstIdx = firstInfo.index.coerceIn(0, itemCount - 1)
     val firstSize = firstInfo.size.coerceAtLeast(1)
     val innerFraction = ((-firstInfo.offset).toFloat() / firstSize).coerceIn(0f, 1f)

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/domain/BuildSearchTreeUseCase.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/domain/BuildSearchTreeUseCase.kt
@@ -12,7 +12,6 @@ class BuildSearchTreeUseCase(
     private val repository: SeforimRepository,
 ) {
     private val bookCache: MutableMap<Long, Book> = mutableMapOf()
-    private val categoryCache: MutableMap<Long, Category> = mutableMapOf()
     private val categoryPathCache: MutableMap<Long, List<Category>> = mutableMapOf()
 
     /**
@@ -66,12 +65,10 @@ class BuildSearchTreeUseCase(
         val categoriesById = mutableMapOf<Long, Category>()
         val booksById = mutableMapOf<Long, Book>()
 
-        // Load categories from cache or repository
+        // Load categories (repository caches them internally)
         for (catId in facetCategoryCounts.keys) {
             currentCoroutineContext().ensureActive()
-            val cat =
-                categoryCache[catId]
-                    ?: repository.getCategory(catId)?.also { categoryCache[catId] = it }
+            val cat = repository.getCategory(catId)
             if (cat != null) {
                 categoriesById[cat.id] = cat
             }
@@ -87,9 +84,7 @@ class BuildSearchTreeUseCase(
                 booksById[book.id] = book
                 // Ensure the book's category is in the tree
                 if (!categoriesById.containsKey(book.categoryId)) {
-                    val cat =
-                        categoryCache[book.categoryId]
-                            ?: repository.getCategory(book.categoryId)?.also { categoryCache[book.categoryId] = it }
+                    val cat = repository.getCategory(book.categoryId)
                     if (cat != null) {
                         categoriesById[cat.id] = cat
                     }
@@ -144,10 +139,7 @@ class BuildSearchTreeUseCase(
         var currentId: Long? = categoryId
         while (currentId != null) {
             currentCoroutineContext().ensureActive()
-            val cat =
-                categoryCache[currentId]
-                    ?: repository.getCategory(currentId)?.also { categoryCache[currentId] = it }
-            if (cat == null) break
+            val cat = repository.getCategory(currentId) ?: break
             path += cat
             currentId = cat.parentId
         }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/domain/CategoryNavigationUseCase.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/domain/CategoryNavigationUseCase.kt
@@ -18,9 +18,6 @@ import kotlinx.coroutines.ensureActive
 class CategoryNavigationUseCase(
     private val repository: SeforimRepository,
 ) {
-    // Cache for category lookups
-    private val categoryCache: MutableMap<Long, Category> = mutableMapOf()
-
     // Cache for category paths
     private val categoryPathCache: MutableMap<Long, List<Category>> = mutableMapOf()
 
@@ -43,10 +40,7 @@ class CategoryNavigationUseCase(
 
         while (currentId != null) {
             currentCoroutineContext().ensureActive()
-            val cat =
-                categoryCache[currentId]
-                    ?: repository.getCategory(currentId)?.also { categoryCache[currentId] = it }
-                    ?: break
+            val cat = repository.getCategory(currentId) ?: break
             path += cat
             currentId = cat.parentId
         }
@@ -78,21 +72,16 @@ class CategoryNavigationUseCase(
     }
 
     /**
-     * Gets a category by ID, using cache.
-     *
-     * @param categoryId The category ID
-     * @return The category, or null if not found
+     * Gets a category by ID. The repository already memoizes category rows, so this
+     * is a thin passthrough kept for call-site ergonomics.
      */
-    suspend fun getCategory(categoryId: Long): Category? {
-        categoryCache[categoryId]?.let { return it }
-        return repository.getCategory(categoryId)?.also { categoryCache[categoryId] = it }
-    }
+    suspend fun getCategory(categoryId: Long): Category? = repository.getCategory(categoryId)
 
     /**
-     * Clears all caches. Call this when category data may have changed.
+     * Clears local path / books caches. Call this when category data may have changed.
+     * (The repository-level category cache is authoritative and cleared independently.)
      */
     fun clearCache() {
-        categoryCache.clear()
         categoryPathCache.clear()
         booksUnderCategoryCache.clear()
     }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/database/PersistentSqliteDriver.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/database/PersistentSqliteDriver.kt
@@ -1,0 +1,138 @@
+package io.github.kdroidfilter.seforimapp.framework.database
+
+import app.cash.sqldelight.Query
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlCursor
+import app.cash.sqldelight.db.SqlPreparedStatement
+import app.cash.sqldelight.driver.jdbc.JdbcCursor
+import app.cash.sqldelight.driver.jdbc.JdbcDriver
+import app.cash.sqldelight.driver.jdbc.JdbcPreparedStatement
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.PreparedStatement
+import java.util.Properties
+
+/**
+ * SQLite JDBC driver backed by a single persistent connection with a per-identifier
+ * [PreparedStatement] cache.
+ *
+ * Profiling (JFR 2026-04-23) showed the stock [app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver]
+ * routing every non-transactional query through `ThreadedConnectionManager` — which
+ * closes and re-opens the SQLite connection after each call, paying `sqlite3_open`
+ * + `sqlite3_prepare` + `sqlite3_close` per query. On a read-only reader workload
+ * that is pure waste: the reader corpus is immutable, so one connection suffices
+ * and every repeatedly-issued query benefits from a cached prepared statement.
+ *
+ * Design:
+ *  - A single [Connection] opened at construction time, kept alive until [close].
+ *  - `getConnection()` returns that connection; `closeConnection()` is a no-op.
+ *  - Read-tuning PRAGMAs applied once at init (WAL / NORMAL sync / page+mmap caches).
+ *  - Prepared-statement cache keyed by SqlDelight's `identifier: Int` — the same
+ *    integer it passes on every generated query call. Statements are synchronized
+ *    on the single connection because SQLite's JDBC connection is not thread-safe.
+ *
+ * Transactions are handled by [JdbcDriver]'s base `autoCommit` machinery; we just
+ * ensure our cached prepared statements aren't handed out while another thread holds
+ * the connection by synchronizing the execute methods on `connection`.
+ */
+class PersistentSqliteDriver(
+    url: String,
+    properties: Properties = Properties(),
+) : JdbcDriver() {
+    private val connection: Connection = DriverManager.getConnection(url, properties)
+
+    // Statement cache keyed by SQL text — SqlDelight sometimes reuses the same
+    // `identifier` for queries whose SQL varies (e.g. `IN (?,?,?)` with variable
+    // arity), so we avoid crashes by keying on the actual SQL string. Bounded in
+    // practice: a few hundred distinct queries across the whole app. Never evicted.
+    private val statementCache = HashMap<String, PreparedStatement>()
+
+    init {
+        connection.autoCommit = true
+        // Don't apply PRAGMAs here: `SeforimRepository.init` already issues its own
+        // tuned set (256 MB cache / 512 MB mmap). Running them twice while the repo
+        // still holds open cursors from its schema-create pass triggers SQLITE_BUSY.
+    }
+
+    override fun getConnection(): Connection = connection
+
+    override fun closeConnection(connection: Connection) = Unit
+
+    override fun close() {
+        synchronized(connection) {
+            statementCache.values.forEach { runCatching { it.close() } }
+            statementCache.clear()
+            connection.close()
+        }
+    }
+
+    override fun addListener(
+        vararg queryKeys: String,
+        listener: Query.Listener,
+    ) = Unit
+
+    override fun removeListener(
+        vararg queryKeys: String,
+        listener: Query.Listener,
+    ) = Unit
+
+    override fun notifyListeners(vararg queryKeys: String) = Unit
+
+    override fun execute(
+        identifier: Int?,
+        sql: String,
+        parameters: Int,
+        binders: (SqlPreparedStatement.() -> Unit)?,
+    ): QueryResult<Long> {
+        synchronized(connection) {
+            val stmt = prepare(sql)
+            stmt.clearParameters()
+            if (binders != null) JdbcPreparedStatement(stmt).binders()
+            val hasResultSet = stmt.execute()
+            val rows =
+                if (hasResultSet) {
+                    // Drain any result set to release the statement's cursor so the next
+                    // call (e.g. a subsequent PRAGMA) doesn't hit SQLITE_BUSY.
+                    stmt.resultSet?.close()
+                    0L
+                } else {
+                    stmt.updateCount.toLong()
+                }
+            return QueryResult.Value(rows)
+        }
+    }
+
+    override fun <R> executeQuery(
+        identifier: Int?,
+        sql: String,
+        mapper: (SqlCursor) -> QueryResult<R>,
+        parameters: Int,
+        binders: (SqlPreparedStatement.() -> Unit)?,
+    ): QueryResult<R> {
+        synchronized(connection) {
+            val stmt = prepare(sql)
+            stmt.clearParameters()
+            if (binders != null) JdbcPreparedStatement(stmt).binders()
+            // Inlined from `JdbcPreparedStatement.executeQuery`, minus the `preparedStatement.close()`
+            // in its `finally` — closing would defeat the whole point of caching. We close the
+            // ResultSet via `.use { }` instead so SQLite frees the cursor for the next call.
+            stmt.executeQuery().use { rs ->
+                return mapper(JdbcCursor(rs))
+            }
+        }
+    }
+
+    /**
+     * Returns a cached [PreparedStatement] for [sql], preparing it lazily on first
+     * use. Caller must hold the connection's monitor.
+     */
+    private fun prepare(sql: String): PreparedStatement {
+        statementCache[sql]?.let { cached ->
+            if (!cached.isClosed) return cached
+            statementCache.remove(sql)
+        }
+        val fresh = connection.prepareStatement(sql)
+        statementCache[sql] = fresh
+        return fresh
+    }
+}

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/di/modules/AppCoreBindings.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/framework/di/modules/AppCoreBindings.kt
@@ -15,6 +15,7 @@ import io.github.kdroidfilter.seforimapp.core.selection.SelectionContext
 import io.github.kdroidfilter.seforimapp.core.settings.CategoryDisplaySettingsStore
 import io.github.kdroidfilter.seforimapp.db.UserSettingsDb
 import io.github.kdroidfilter.seforimapp.features.search.SearchHomeViewModel
+import io.github.kdroidfilter.seforimapp.framework.database.PersistentSqliteDriver
 import io.github.kdroidfilter.seforimapp.framework.database.getDatabasePath
 import io.github.kdroidfilter.seforimapp.framework.database.getUserSettingsDatabasePath
 import io.github.kdroidfilter.seforimapp.framework.desktop.DesktopManager
@@ -66,7 +67,11 @@ object AppCoreBindings {
     @SingleIn(AppScope::class)
     fun provideRepository(): SeforimRepository {
         val dbPath = getDatabasePath()
-        val driver = JdbcSqliteDriver("jdbc:sqlite:$dbPath")
+        // Persistent single-connection driver with prepared-statement cache +
+        // read-tuning PRAGMAs. Replaces `JdbcSqliteDriver` whose ThreadedConnectionManager
+        // closes the SQLite connection after every non-transactional query (confirmed by
+        // JFR 2026-04-23: ~70 `NativeDB.prepare_utf8` + `NativeDB._close()` pairs / 20 s).
+        val driver = PersistentSqliteDriver("jdbc:sqlite:$dbPath")
         return SeforimRepository(dbPath, driver)
     }
 


### PR DESCRIPTION
## Summary

Eliminate the dominant CPU hot spot flagged by the JFR 2026-04-23 profile (70 `sqlite3_prepare` / `sqlite3_close` pairs in 20 s, all from `getCategory` walks) plus a few cheap scrollbar wins.

**1. `PersistentSqliteDriver`** (new)
Replaces the stock `JdbcSqliteDriver`. Single persistent `Connection` + SQL-keyed `PreparedStatement` cache. The stock driver's `ThreadedConnectionManager` closes the SQLite connection after every non-transactional query — paying `sqlite3_open` + `prepare` + `close` per call on a read-only reader workload. The new driver:
- Keeps one `Connection` alive for the repository's lifetime
- Caches `PreparedStatement` by SQL text (handles variable-arity `IN (?)` correctly — same identifier, different SQL)
- Drains the `ResultSet` after `execute()` so subsequent PRAGMAs don't hit `SQLITE_BUSY`
- PRAGMAs stay in `SeforimRepository.init` to avoid double-application

**2. Drop local `categoryCache` maps** in `CategoryNavigationUseCase` and `BuildSearchTreeUseCase`
Now redundant with the repository-level cache in `SeforimLibrary#71`. Single authoritative cache.

**3. Scrollbar micro-opts** (< 1% CPU, but clean)
- Convergence `LaunchedEffect` in `ContentAwareScrollbarShell` no longer keys on `position` — a `snapshotFlow` inside the effect body observes it only while a drag target is pinned, eliminating 60 Hz effect churn during idle scrolls.
- `visibleItemsInfo.filter { }` replaced by a single-pass scan in `computeBookPosition` / `computeScrollPosition` across the three scrollbars — no per-frame `List` allocation.

## Profiling impact

| Metric | Before (JFR 2026-04-23, 20 s) | After (JFR 2026-04-24, 53 s) | Delta |
|---|---|---|---|
| `NativeDB.prepare_utf8` samples | 74 | 1 | **−99%** |
| `NativeDB._close` samples | 8 | 0 | **−100%** |
| `getCategory` samples | 70 | 0 | **−100%** |
| `getCommentarySummariesForLines` samples | 19 | 4 | −80% |
| `getBookPubDates` samples | 6 | 0 | −100% |
| Scrollbar samples / s | 1.55 | 0.52 | −66% |
| CPU user (idle, max) | 17.5% | 3.5% | **−80%** |
| CPU user (idle, modal) | 7.5% | 1.5% | −80% |

## Test plan
- [x] `./gradlew :SeforimApp:compileKotlinJvm` passes
- [x] `./gradlew ktlintCheck detekt` clean
- [x] App starts, loads catalog (1345 categories, 7156 books) without error
- [x] Second profiling run confirms hot spot gone
- [ ] Manual: open a book, scroll, verify thumb tracks content and far-drag works
- [ ] Requires SeforimLibrary#71 to land first (submodule bumped to `0166168`)