### PR TITLE
Add menu group for Linux packaging

### DIFF
--- a/SeforimApp/build.gradle.kts
+++ b/SeforimApp/build.gradle.kts
@@ -296,6 +296,7 @@ nucleus.application {
             iconFile.set(project.file("desktopAppIcons/LinuxIcon.png"))
             packageVersion = version
             debMaintainer = "elyahou.hadass@gmail.com"
+            menuGroup = "Education"
         }
         windows {
             iconFile.set(project.file("desktopAppIcons/WindowsIcon.ico"))


### PR DESCRIPTION
Adds Zayit to _Education_ category instead of _Lost & Found_ on Linux systems.
-----
יישר כוח ענק על האפליקציה!