### PR TITLE
feat(search): open zayit:// deep links pasted into the search bar

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsContent.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsContent.kt
@@ -170,6 +170,9 @@ fun TabsContent() {
                         ),
                     )
                 }
+                is SearchHomeNavigationEvent.NavigateToDeepLink -> {
+                    tabsViewModel.replaceCurrentTabDestination(event.destination)
+                }
             }
         }
     }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchHomeViewModel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/search/SearchHomeViewModel.kt
@@ -5,7 +5,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.russhwolf.settings.Settings
 import com.russhwolf.settings.get
+import io.github.kdroidfilter.seforim.tabs.TabsDestination
 import io.github.kdroidfilter.seforimapp.core.coroutines.runSuspendCatching
+import io.github.kdroidfilter.seforimapp.core.deeplink.parseZayitDeepLink
 import io.github.kdroidfilter.seforimapp.core.settings.AppSettings
 import io.github.kdroidfilter.seforimapp.framework.search.LuceneLookupSearchService
 import io.github.kdroidfilter.seforimapp.framework.session.SearchPersistedState
@@ -59,6 +61,14 @@ sealed class SearchHomeNavigationEvent {
         val bookId: Long,
         val tabId: String,
         val lineId: Long?,
+    ) : SearchHomeNavigationEvent()
+
+    /**
+     * Navigate to a destination resolved from a zayit:// deep link pasted into the search bar.
+     * @param destination The parsed destination (book/line or search)
+     */
+    data class NavigateToDeepLink(
+        val destination: TabsDestination,
     ) : SearchHomeNavigationEvent()
 }
 
@@ -495,6 +505,20 @@ class SearchHomeViewModel(
         query: String,
         currentTabId: String,
     ) {
+        // A zayit:// link pasted into the search bar opens the target instead of running a search.
+        parseZayitDeepLink(query.trim())?.let { destination ->
+            val resolvable =
+                when (destination) {
+                    is TabsDestination.BookContent ->
+                        runSuspendCatching { repository.getBookCore(destination.bookId) }.getOrNull() != null
+                    else -> true
+                }
+            if (resolvable) {
+                _navigationEvents.send(SearchHomeNavigationEvent.NavigateToDeepLink(destination))
+                return
+            }
+        }
+
         // Apply selected scope only (view filters) and persist dataset scope for fetch
         val selected = _uiState.value
         val datasetScope: String


### PR DESCRIPTION
## Summary
- Pasting a `zayit://book/<id>/line/<lineId>` (or `zayit://search/...`) link into the main search bar now opens the target directly instead of running a text search.
- `submitSearch` parses the query with `parseZayitDeepLink`; on a match it validates the book exists (`getBookCore`) and emits a new `NavigateToDeepLink` event.
- `TabsContent` handles the event by replacing the current tab's destination, reusing the existing deep-link parsing already used for external links.

## Test plan
- [ ] Paste `zayit://book/247/line/169673` → opens the book at the line
- [ ] Paste `zayit://search/...` → opens the search
- [ ] A normal text query still runs a search
- [ ] A link to a non-existent book falls back to a normal search