### PR TITLE
Display notes oldest-first with the draft editor at the bottom

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/notes/NotesPanel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/notes/NotesPanel.kt
@@ -120,7 +120,8 @@ fun NotesPanel(
             notesByBook[bookId]
                 .orEmpty()
                 .filter { it.lineId in selectedLineIds }
-                .sortedWith(compareBy({ it.lineId }, { it.startOffset }))
+                // Oldest first: [id] is AUTOINCREMENT, so it grows in insertion order.
+                .sortedBy { it.id }
         }
 
     val primaryLineId = primarySelectedLine?.id
@@ -186,6 +187,24 @@ fun NotesPanel(
                     state = listState,
                     modifier = Modifier.fillMaxSize().padding(horizontal = 8.dp, vertical = 4.dp),
                 ) {
+                    items(notes, key = { it.id }) { note ->
+                        NoteCard(quote = note.quote.takeIf { it.isNotBlank() }) {
+                            NoteEditor(
+                                initialText = note.note,
+                                autoFocus = false,
+                                clearOnDelete = false,
+                                onPersist = { text ->
+                                    scope.launch {
+                                        // A blank body deletes the note (NoteStore.updateNote contract).
+                                        noteStore.updateNote(bookId, note.id, text, System.currentTimeMillis())
+                                    }
+                                },
+                                onDelete = { scope.launch { noteStore.removeNote(bookId, note.id) } },
+                            )
+                        }
+                    }
+                    // Draft editor last: the new (most recent) note belongs after the existing ones,
+                    // which are listed oldest-first.
                     if (effectiveDraft != null) {
                         item(
                             key =
@@ -232,22 +251,6 @@ fun NotesPanel(
                                     },
                                 )
                             }
-                        }
-                    }
-                    items(notes, key = { it.id }) { note ->
-                        NoteCard(quote = note.quote.takeIf { it.isNotBlank() }) {
-                            NoteEditor(
-                                initialText = note.note,
-                                autoFocus = false,
-                                clearOnDelete = false,
-                                onPersist = { text ->
-                                    scope.launch {
-                                        // A blank body deletes the note (NoteStore.updateNote contract).
-                                        noteStore.updateNote(bookId, note.id, text, System.currentTimeMillis())
-                                    }
-                                },
-                                onDelete = { scope.launch { noteStore.removeNote(bookId, note.id) } },
-                            )
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Sort the notes pane chronologically (oldest first) instead of by text position.
- Uses the `AUTOINCREMENT` `id` as the ordering key, since it grows in insertion order — no schema or model change needed.
- Move the draft / add-note editor below the existing notes, so the most recent note (the one being written) sits at the bottom, consistent with the oldest-first order.

## Notes
- Drafting behavior is unchanged: a created note stays in the bottom editor (kept out of the list via `draftCreatedId`) without losing focus, then rejoins the list at its chronological place on save/selection change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)