### PR TITLE
Fix parasha name to respect Israel/Diaspora setting

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeCelestialWidgets.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeCelestialWidgets.kt
@@ -64,6 +64,7 @@ import io.github.kdroidfilter.seforimapp.earthwidget.ZmanimOpinion
 import io.github.kdroidfilter.seforimapp.earthwidget.computeZmanimTimes
 import io.github.kdroidfilter.seforimapp.earthwidget.timeZoneForLocation
 import io.github.kdroidfilter.seforimapp.features.onboarding.userprofile.Community
+import io.github.kdroidfilter.seforimapp.features.zmanim.data.ISRAEL_COUNTRY_NAME
 import io.github.kdroidfilter.seforimapp.features.zmanim.data.worldPlaces
 import io.github.kdroidfilter.seforimapp.framework.di.LocalAppGraph
 import io.github.kdroidfilter.seforimapp.theme.PreviewContainer
@@ -293,6 +294,7 @@ fun HomeCelestialWidgets(
     // Temporary location selection (does not affect user settings)
     var temporaryLocation by remember { mutableStateOf<EarthWidgetLocation?>(null) }
     var temporaryCityLabel by remember { mutableStateOf<String?>(null) }
+    var temporaryInIsrael by remember { mutableStateOf<Boolean?>(null) }
 
     // Use temporary location if selected, otherwise fall back to user's saved location
     val effectiveLocation =
@@ -306,6 +308,7 @@ fun HomeCelestialWidgets(
             )
         }
     val effectiveCityLabel = temporaryCityLabel ?: userCityLabel
+    val effectiveInIsrael = temporaryInIsrael ?: locationState.inIsrael
     val timeZone = effectiveLocation.timeZone
 
     // Shared date state - controls both the Earth widget and zmanim cards
@@ -318,8 +321,8 @@ fun HomeCelestialWidgets(
             computeZmanimTimes(selectedDate, effectiveLocation, zmanimOpinion)
         }
     val shabbatTimes =
-        remember(selectedDate, effectiveLocation, zmanimOpinion, effectiveCityLabel) {
-            computeShabbatTimes(selectedDate, effectiveLocation, zmanimOpinion, effectiveCityLabel)
+        remember(selectedDate, effectiveLocation, zmanimOpinion, effectiveCityLabel, effectiveInIsrael) {
+            computeShabbatTimes(selectedDate, effectiveLocation, zmanimOpinion, effectiveCityLabel, effectiveInIsrael)
         }
     val timeFormatter =
         remember(timeZone) {
@@ -358,9 +361,10 @@ fun HomeCelestialWidgets(
     }
 
     // When selecting a location in the Earth widget, update temporary location (without changing user settings)
-    val onLocationSelectedHandler: (String, String, EarthWidgetLocation) -> Unit = { _, city, location ->
+    val onLocationSelectedHandler: (String, String, EarthWidgetLocation) -> Unit = { country, city, location ->
         temporaryLocation = location
         temporaryCityLabel = city
+        temporaryInIsrael = country == ISRAEL_COUNTRY_NAME
         // Reset target time when location changes
         earthWidgetTargetTime = null
     }
@@ -2018,6 +2022,7 @@ private fun computeShabbatTimes(
     location: EarthWidgetLocation,
     opinion: ZmanimOpinion = ZmanimOpinion.DEFAULT,
     cityLabel: String? = null,
+    inIsrael: Boolean = false,
 ): ShabbatTimes {
     val shabbatDate = date.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY))
     val fridayDate = shabbatDate.minusDays(1)
@@ -2046,6 +2051,7 @@ private fun computeShabbatTimes(
         run {
             val jewishCalendar =
                 JewishCalendar().apply {
+                    setInIsrael(inIsrael)
                     setDate(calendarForDate(shabbatDate))
                 }
             val formatter =

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeCelestialWidgetsViewModel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeCelestialWidgetsViewModel.kt
@@ -5,6 +5,7 @@ import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import io.github.kdroidfilter.seforimapp.core.settings.AppSettings
+import io.github.kdroidfilter.seforimapp.features.zmanim.data.ISRAEL_COUNTRY_NAME
 import io.github.kdroidfilter.seforimapp.features.zmanim.data.Place
 import io.github.kdroidfilter.seforimapp.features.zmanim.data.worldPlaces
 import io.github.kdroidfilter.seforimapp.framework.di.AppScope
@@ -15,12 +16,14 @@ import kotlinx.coroutines.flow.asStateFlow
 data class HomeCelestialWidgetsState(
     val userPlace: Place,
     val userCityLabel: String?,
+    val inIsrael: Boolean,
 ) {
     companion object {
         val preview =
             HomeCelestialWidgetsState(
                 userPlace = DEFAULT_PLACE,
                 userCityLabel = null,
+                inIsrael = true,
             )
     }
 }
@@ -47,6 +50,7 @@ class HomeCelestialWidgetsViewModel : ViewModel() {
         return HomeCelestialWidgetsState(
             userPlace = place ?: DEFAULT_PLACE,
             userCityLabel = city?.takeIf { it.isNotBlank() },
+            inIsrael = country == ISRAEL_COUNTRY_NAME,
         )
     }
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/zmanim/data/Cities.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/zmanim/data/Cities.kt
@@ -7,6 +7,9 @@ data class Place(
     val elevation: Double,
 )
 
+/** Country key used to identify Israel (vs. Diaspora / Chutz LaAretz). */
+const val ISRAEL_COUNTRY_NAME = "ישראל"
+
 /** Countries → Cities → Place */
 val worldPlaces: Map<String, Map<String, Place>> =
     mapOf(


### PR DESCRIPTION
## Problème

Le nom de la paracha hebdomadaire était calculé avec la valeur par défaut de KosherJava `inIsrael=false`, affichant donc **toujours le cycle de lecture de la diaspora** quel que soit le réglage région de l'utilisateur. Les deux cycles divergent plusieurs semaines par an (typiquement après Pessah/Chavouot, jusqu'à une paracha double qui les resynchronise) — les utilisateurs en Israël voyaient donc la mauvaise paracha.

## Correctif

- `computeShabbatTimes` reçoit un flag `inIsrael` dérivé du réglage région de l'utilisateur (`region_country == "ישראל"`) et le passe à `JewishCalendar.setInIsrael()`.
- La sélection de ville temporaire met à jour le flag depuis son pays, pour que la paracha affichée reste cohérente avec les horaires.
- Constante `ISRAEL_COUNTRY_NAME` ajoutée dans `Cities.kt` pour éviter de dupliquer la chaîne hébraïque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)