### PR TITLE
Fix empty sources pane by querying inverse commentary links

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/usecases/CommentariesUseCase.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/usecases/CommentariesUseCase.kt
@@ -1032,7 +1032,7 @@ class CommentariesUseCase(
             val baseIds = resolveBaseLineIds(lineId)
             val links =
                 repository
-                    .getCommentarySummariesForLines(baseIds)
+                    .getCommentarySummariesForLines(baseIds, includeSources = true)
                     .filter { it.link.connectionType == ConnectionType.SOURCE }
 
             val currentBookTitle = selectedBook.title.trim()
@@ -1073,7 +1073,7 @@ class CommentariesUseCase(
         val currentState = stateManager.state.first()
         val selectedBook = currentState.navigation.selectedBook
 
-        val allConnections = repository.getCommentarySummariesForLines(allBaseIds)
+        val allConnections = repository.getCommentarySummariesForLines(allBaseIds, includeSources = true)
         if (allConnections.isEmpty()) return storeAndMerge(missing.associateWith { LineConnectionsSnapshot() })
 
         val connectionsBySource = allConnections.groupBy { it.link.sourceLineId }


### PR DESCRIPTION
## Summary
- The "source" (מקור) button stayed disabled and the sources pane rendered no text.
- Root cause: `ConnectionType.SOURCE` links are virtual — they are derived by querying commentary links in the **inverse** direction, which only happens when `getCommentarySummariesForLines` is called with `includeSources = true`.
- Two call sites were missing that flag:
  - `getAvailableSources()` — drives the source button's enabled state.
  - the `loadLineConnections()` snapshot cache — drives the sources pane content (the pane reads `snapshot.sources`, falling back to availability lookup only when the cache is `null`, so an empty-but-non-null map left the pane blank).

## Test plan
- [ ] Open a base text, open the commentaries pane, open a commentary, then click "source".
- [ ] Verify the source button is enabled and the pane shows the original/base text the commentary references.
- [ ] Confirm books without inverse links still show the empty state and the button stays disabled.