### PR TITLE
test: align BookContent test suite with current code

### DIFF
--- a/SeforimApp/src/jvmTest/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/PostSelectLineTest.kt
+++ b/SeforimApp/src/jvmTest/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/PostSelectLineTest.kt
@@ -13,6 +13,7 @@ import io.github.kdroidfilter.seforimapp.features.bookcontent.usecases.CategoryD
 import io.github.kdroidfilter.seforimapp.features.bookcontent.usecases.CommentariesUseCase
 import io.github.kdroidfilter.seforimapp.features.bookcontent.usecases.ContentUseCase
 import io.github.kdroidfilter.seforimapp.features.bookcontent.usecases.NavigationUseCase
+import io.github.kdroidfilter.seforimapp.features.bookcontent.usecases.NotesUseCase
 import io.github.kdroidfilter.seforimapp.features.bookcontent.usecases.TocUseCase
 import io.github.kdroidfilter.seforimapp.framework.session.TabPersistedStateStore
 import io.github.kdroidfilter.seforimlibrary.core.models.AltTocEntry
@@ -58,6 +59,7 @@ class PostSelectLineTest {
     private lateinit var altTocUseCase: AltTocUseCase
     private lateinit var tocUseCase: TocUseCase
     private lateinit var navigationUseCase: NavigationUseCase
+    private lateinit var notesUseCase: NotesUseCase
     private lateinit var categoryDisplaySettingsUseCase: CategoryDisplaySettingsUseCase
 
     // Captured from factory calls so we can manipulate VM-internal state
@@ -82,6 +84,7 @@ class PostSelectLineTest {
         altTocUseCase = mockk(relaxed = true)
         tocUseCase = mockk(relaxed = true)
         navigationUseCase = mockk(relaxed = true)
+        notesUseCase = mockk(relaxed = true)
         categoryDisplaySettingsUseCase = mockk(relaxed = true)
 
         // CategoryDisplaySettingsUseCase.categoryChanges must return a flow
@@ -99,6 +102,7 @@ class PostSelectLineTest {
                 every { createCommentariesUseCase(any(), any()) } returns commentariesUseCase
                 every { createAltTocUseCase(any()) } returns altTocUseCase
                 every { createTocUseCase(any()) } returns tocUseCase
+                every { createNotesUseCase(any()) } returns notesUseCase
                 every { createCategoryDisplaySettingsUseCase() } returns categoryDisplaySettingsUseCase
             }
 

--- a/SeforimApp/src/jvmTest/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeCelestialWidgetsStateTest.kt
+++ b/SeforimApp/src/jvmTest/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeCelestialWidgetsStateTest.kt
@@ -16,6 +16,7 @@ class HomeCelestialWidgetsStateTest {
             HomeCelestialWidgetsState(
                 userPlace = testPlace,
                 userCityLabel = null,
+                inIsrael = false,
             )
         assertEquals(testPlace, state.userPlace)
     }
@@ -26,6 +27,7 @@ class HomeCelestialWidgetsStateTest {
             HomeCelestialWidgetsState(
                 userPlace = testPlace,
                 userCityLabel = "Paris",
+                inIsrael = false,
             )
         assertEquals("Paris", state.userCityLabel)
     }
@@ -36,6 +38,7 @@ class HomeCelestialWidgetsStateTest {
             HomeCelestialWidgetsState(
                 userPlace = testPlace,
                 userCityLabel = null,
+                inIsrael = false,
             )
         assertNull(state.userCityLabel)
     }
@@ -59,6 +62,7 @@ class HomeCelestialWidgetsStateTest {
             HomeCelestialWidgetsState(
                 userPlace = testPlace,
                 userCityLabel = "Original",
+                inIsrael = false,
             )
         val modified = original.copy(userCityLabel = "Modified")
 
@@ -68,9 +72,9 @@ class HomeCelestialWidgetsStateTest {
 
     @Test
     fun `equals works correctly`() {
-        val state1 = HomeCelestialWidgetsState(userPlace = testPlace, userCityLabel = "A")
-        val state2 = HomeCelestialWidgetsState(userPlace = testPlace, userCityLabel = "A")
-        val state3 = HomeCelestialWidgetsState(userPlace = testPlace, userCityLabel = "B")
+        val state1 = HomeCelestialWidgetsState(userPlace = testPlace, userCityLabel = "A", inIsrael = false)
+        val state2 = HomeCelestialWidgetsState(userPlace = testPlace, userCityLabel = "A", inIsrael = false)
+        val state3 = HomeCelestialWidgetsState(userPlace = testPlace, userCityLabel = "B", inIsrael = false)
 
         assertEquals(state1, state2)
         assertTrue(state1 != state3)


### PR DESCRIPTION
## Summary
Fixes two latent test failures that were invisible because the jvmTest source set failed to compile (one broken file blocked the whole set).

- **HomeCelestialWidgetsStateTest** — add the new `inIsrael` field to every `HomeCelestialWidgetsState(...)` construction.
- **PostSelectLineTest** — mock `NotesUseCase` and stub the new `BookContentUseCaseFactory.createNotesUseCase()` (was throwing `MockKException: no answer found`).

## Test plan
- `./gradlew :SeforimApp:jvmTest` → 1023 tests, 0 failures.