### PR TITLE
feat(commentaries): configurable max commentators per page

### DIFF
--- a/SeforimApp/src/commonMain/composeResources/values/strings.xml
+++ b/SeforimApp/src/commonMain/composeResources/values/strings.xml
@@ -348,6 +348,9 @@
     <string name="settings_show_home_wallpaper_description">כאשר אפשרות זו מופעלת, יוצג נוף של כרם זיתים כרקע דקורטיבי בדף הבית.</string>
     <string name="settings_compact_mode">מצב קומפקטי לסרגל הצדדי</string>
     <string name="settings_compact_mode_description">כאשר אפשרות זו מופעלת, הסרגלים הצדדיים יוצגו בצורה צפופה יותר: האייקונים יהיו קטנים יותר והטקסט שמתחת לאייקונים לא יוצג.</string>
+    <string name="settings_max_commentators_per_page">מספר מרבי של מפרשים בעמוד</string>
+    <string name="settings_max_commentators_per_page_description">קובע כמה מפרשים יוצגו לכל היותר בעמוד אחד. כאשר נבחר "אוטומטי", המספר מותאם לגודל המסך. הגבלה למספר מסוים תיצור עמודים נוספים כשיש יותר מפרשים, אך כאשר יש מקום לפחות מכך יוצגו רק מה שנכנס.</string>
+    <string name="settings_max_commentators_per_page_auto">אוטומטי</string>
     <!-- Theme style selector -->
     <string name="settings_theme_style_label">סגנון ערכת נושא</string>
     <string name="settings_theme_style_classic">קלאסי</string>

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/settings/AppSettings.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/settings/AppSettings.kt
@@ -28,6 +28,14 @@ object AppSettings {
     const val MAX_LINE_HEIGHT = 2.5f
     const val LINE_HEIGHT_INCREMENT = 0.1f
 
+    // Max commentators displayed per commentaries page.
+    // 0 = automatic (fit as many as the available space allows). A positive value acts as a
+    // ceiling: the grid never shows more than this per page, but still shows fewer when the
+    // pane only has room for fewer.
+    const val MAX_COMMENTATORS_PER_PAGE_AUTO = 0
+    const val MAX_COMMENTATORS_PER_PAGE_LIMIT = 6
+    const val DEFAULT_MAX_COMMENTATORS_PER_PAGE = MAX_COMMENTATORS_PER_PAGE_AUTO
+
     // Default font codes
     const val DEFAULT_BOOK_FONT = "notoserifhebrew"
     const val DEFAULT_COMMENTARY_FONT = "frankruhllibre"
@@ -43,6 +51,7 @@ object AppSettings {
     // Settings keys
     private const val KEY_TEXT_SIZE = "text_size"
     private const val KEY_LINE_HEIGHT = "line_height"
+    private const val KEY_MAX_COMMENTATORS_PER_PAGE = "max_commentators_per_page"
     private const val KEY_CLOSE_TREE_ON_NEW_BOOK = "close_tree_on_new_book"
     private const val KEY_DATABASE_PATH = "database_path"
     private const val KEY_PERSIST_SESSION = "persist_session"
@@ -92,6 +101,7 @@ object AppSettings {
         // Refresh flows with current values from provided settings
         _textSizeFlow.value = getTextSize()
         _lineHeightFlow.value = getLineHeight()
+        _maxCommentatorsPerPageFlow.value = getMaxCommentatorsPerPage()
         _closeTreeOnNewBookFlow.value = getCloseBookTreeOnNewBookSelected()
         _databasePathFlow.value = getDatabasePath()
         _persistSessionFlow.value = isPersistSessionEnabled()
@@ -113,6 +123,10 @@ object AppSettings {
     // StateFlow to observe line height changes
     private val _lineHeightFlow = MutableStateFlow(getLineHeight())
     val lineHeightFlow: StateFlow<Float> = _lineHeightFlow.asStateFlow()
+
+    // StateFlow to observe the max-commentators-per-page setting
+    private val _maxCommentatorsPerPageFlow = MutableStateFlow(getMaxCommentatorsPerPage())
+    val maxCommentatorsPerPageFlow: StateFlow<Int> = _maxCommentatorsPerPageFlow.asStateFlow()
 
     // StateFlow for auto-close book tree setting
     private val _closeTreeOnNewBookFlow = MutableStateFlow(getCloseBookTreeOnNewBookSelected())
@@ -225,6 +239,18 @@ object AppSettings {
         val currentSize = getTextSize()
         val newSize = (currentSize - decrement).coerceAtLeast(MIN_TEXT_SIZE)
         setTextSize(newSize)
+    }
+
+    // Max commentators per commentaries page (0 = automatic). Stored value is clamped to the
+    // supported range so a stale or out-of-range persisted value can never break the grid.
+    fun getMaxCommentatorsPerPage(): Int =
+        settings[KEY_MAX_COMMENTATORS_PER_PAGE, DEFAULT_MAX_COMMENTATORS_PER_PAGE]
+            .coerceIn(MAX_COMMENTATORS_PER_PAGE_AUTO, MAX_COMMENTATORS_PER_PAGE_LIMIT)
+
+    fun setMaxCommentatorsPerPage(value: Int) {
+        val clamped = value.coerceIn(MAX_COMMENTATORS_PER_PAGE_AUTO, MAX_COMMENTATORS_PER_PAGE_LIMIT)
+        settings[KEY_MAX_COMMENTATORS_PER_PAGE] = clamped
+        _maxCommentatorsPerPageFlow.value = clamped
     }
 
     fun getLineHeight(): Float = settings[KEY_LINE_HEIGHT, DEFAULT_LINE_HEIGHT]
@@ -506,6 +532,7 @@ object AppSettings {
         settings.clear()
         _textSizeFlow.value = DEFAULT_TEXT_SIZE
         _lineHeightFlow.value = DEFAULT_LINE_HEIGHT
+        _maxCommentatorsPerPageFlow.value = DEFAULT_MAX_COMMENTATORS_PER_PAGE
         _closeTreeOnNewBookFlow.value = false
         _databasePathFlow.value = null
         _persistSessionFlow.value = true

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/CommentatorsGrid.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/CommentatorsGrid.kt
@@ -88,11 +88,16 @@ internal data class CommentariesPageLayout(
 /**
  * Derive the commentaries grid capacity from the pane size and the user's commentary
  * font size. Pure helper — extracted so it can be unit-tested without Compose.
+ *
+ * [maxPerPage] is the user-configured ceiling on commentators per page: 0 means automatic
+ * (no cap). A positive value only ever lowers the computed capacity — when the pane has room
+ * for fewer than the cap, the smaller fit-based count wins.
  */
 internal fun computeCommentariesGridCapacity(
     paneWidthDp: Float,
     paneHeightDp: Float,
     commentTextSize: Float,
+    maxPerPage: Int = 0,
 ): CommentariesGridCapacity {
     val rawScale = commentTextSize / REFERENCE_TEXT_SIZE
     val textScale =
@@ -108,7 +113,16 @@ internal fun computeCommentariesGridCapacity(
     if (cols * rows < 2 && paneWidthDp >= NARROW_PANE_WIDTH.value) {
         if (paneWidthDp >= paneHeightDp) cols = 2 else rows = 2
     }
-    return CommentariesGridCapacity(cols = cols, rows = rows, perPage = cols * rows)
+    var perPage = cols * rows
+    // Apply the user ceiling, shrinking cols/rows so the layout stays consistent with the
+    // capped count. Capping never raises capacity, so a narrow pane that only fits 1 still
+    // shows 1 even when the cap is higher.
+    if (maxPerPage in 1 until perPage) {
+        perPage = maxPerPage
+        cols = cols.coerceAtMost(perPage)
+        rows = ((perPage + cols - 1) / cols).coerceAtLeast(1)
+    }
+    return CommentariesGridCapacity(cols = cols, rows = rows, perPage = perPage)
 }
 
 /**
@@ -160,6 +174,7 @@ internal fun CommentatorsGridScaffold(
                 paneWidthDp = maxWidth.value,
                 paneHeightDp = maxHeight.value,
                 commentTextSize = config.textSizes.commentTextSize,
+                maxPerPage = config.maxCommentatorsPerPage,
             )
         val cols = capacity.cols
         val perPage = capacity.perPage

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
@@ -1175,6 +1175,7 @@ internal data class CommentariesLayoutConfig(
     val boldScale: Float,
     val highlightQuery: String,
     val showDiacritics: Boolean,
+    val maxCommentatorsPerPage: Int,
 )
 
 @Composable
@@ -1189,6 +1190,7 @@ private fun rememberCommentariesLayoutConfig(
     val windowInfo = LocalWindowInfo.current
     val commentaryFontCode by AppSettings.commentaryFontCodeFlow.collectAsState()
     val commentaryFontFamily = FontCatalog.familyFor(commentaryFontCode)
+    val maxCommentatorsPerPage by AppSettings.maxCommentatorsPerPageFlow.collectAsState()
     val boldScaleForPlatform =
         remember(commentaryFontCode) {
             val lacksBold = commentaryFontCode in setOf("notoserifhebrew", "notorashihebrew", "frankruhllibre")
@@ -1203,6 +1205,7 @@ private fun rememberCommentariesLayoutConfig(
         boldScaleForPlatform,
         findQueryText,
         showDiacritics,
+        maxCommentatorsPerPage,
     ) {
         CommentariesLayoutConfig(
             selectedCommentators = selectedCommentators,
@@ -1226,6 +1229,7 @@ private fun rememberCommentariesLayoutConfig(
             boldScale = boldScaleForPlatform,
             highlightQuery = findQueryText,
             showDiacritics = showDiacritics,
+            maxCommentatorsPerPage = maxCommentatorsPerPage,
         )
     }
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/display/DisplaySettingsEvents.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/display/DisplaySettingsEvents.kt
@@ -12,4 +12,8 @@ sealed interface DisplaySettingsEvents {
     data class SetCompactMode(
         val value: Boolean,
     ) : DisplaySettingsEvents
+
+    data class SetMaxCommentatorsPerPage(
+        val value: Int,
+    ) : DisplaySettingsEvents
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/display/DisplaySettingsState.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/display/DisplaySettingsState.kt
@@ -7,6 +7,7 @@ data class DisplaySettingsState(
     val showZmanimWidgets: Boolean = true,
     val showHomeWallpaper: Boolean = true,
     val compactMode: Boolean = false,
+    val maxCommentatorsPerPage: Int = 0,
 ) {
     companion object {
         val preview =
@@ -14,6 +15,7 @@ data class DisplaySettingsState(
                 showZmanimWidgets = true,
                 showHomeWallpaper = true,
                 compactMode = false,
+                maxCommentatorsPerPage = 0,
             )
     }
 }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/display/DisplaySettingsViewModel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/display/DisplaySettingsViewModel.kt
@@ -19,13 +19,15 @@ class DisplaySettingsViewModel : ViewModel() {
     private val showZmanim = MutableStateFlow(AppSettings.isShowZmanimWidgetsEnabled())
     private val showHomeWallpaper = MutableStateFlow(AppSettings.isShowHomeWallpaperEnabled())
     private val compactMode = MutableStateFlow(AppSettings.isCompactModeEnabled())
+    private val maxCommentatorsPerPage = MutableStateFlow(AppSettings.getMaxCommentatorsPerPage())
 
     val state =
-        combine(showZmanim, showHomeWallpaper, compactMode) { z, wallpaper, compact ->
+        combine(showZmanim, showHomeWallpaper, compactMode, maxCommentatorsPerPage) { z, wallpaper, compact, maxCommentators ->
             DisplaySettingsState(
                 showZmanimWidgets = z,
                 showHomeWallpaper = wallpaper,
                 compactMode = compact,
+                maxCommentatorsPerPage = maxCommentators,
             )
         }.stateIn(
             viewModelScope,
@@ -34,6 +36,7 @@ class DisplaySettingsViewModel : ViewModel() {
                 showZmanimWidgets = showZmanim.value,
                 showHomeWallpaper = showHomeWallpaper.value,
                 compactMode = compactMode.value,
+                maxCommentatorsPerPage = maxCommentatorsPerPage.value,
             ),
         )
 
@@ -50,6 +53,10 @@ class DisplaySettingsViewModel : ViewModel() {
             is DisplaySettingsEvents.SetCompactMode -> {
                 AppSettings.setCompactModeEnabled(event.value)
                 compactMode.value = event.value
+            }
+            is DisplaySettingsEvents.SetMaxCommentatorsPerPage -> {
+                AppSettings.setMaxCommentatorsPerPage(event.value)
+                maxCommentatorsPerPage.value = AppSettings.getMaxCommentatorsPerPage()
             }
         }
     }

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/DisplaySettingsScreen.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/settings/ui/DisplaySettingsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,6 +32,7 @@ import dev.zacsweers.metrox.viewmodel.metroViewModel
 import io.github.kdroidfilter.seforimapp.core.presentation.theme.AccentColor
 import io.github.kdroidfilter.seforimapp.core.presentation.theme.ThemeStyle
 import io.github.kdroidfilter.seforimapp.core.presentation.utils.LocalWindowViewModelStoreOwner
+import io.github.kdroidfilter.seforimapp.core.settings.AppSettings
 import io.github.kdroidfilter.seforimapp.features.settings.display.DisplaySettingsEvents
 import io.github.kdroidfilter.seforimapp.features.settings.display.DisplaySettingsState
 import io.github.kdroidfilter.seforimapp.features.settings.display.DisplaySettingsViewModel
@@ -38,6 +40,7 @@ import io.github.kdroidfilter.seforimapp.framework.di.LocalAppGraph
 import io.github.kdroidfilter.seforimapp.theme.PreviewContainer
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.ListComboBox
 import org.jetbrains.jewel.ui.component.RadioButtonRow
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.VerticallyScrollableContainer
@@ -50,6 +53,9 @@ import seforimapp.seforimapp.generated.resources.accent_color_teal
 import seforimapp.seforimapp.generated.resources.settings_accent_color_label
 import seforimapp.seforimapp.generated.resources.settings_compact_mode
 import seforimapp.seforimapp.generated.resources.settings_compact_mode_description
+import seforimapp.seforimapp.generated.resources.settings_max_commentators_per_page
+import seforimapp.seforimapp.generated.resources.settings_max_commentators_per_page_auto
+import seforimapp.seforimapp.generated.resources.settings_max_commentators_per_page_description
 import seforimapp.seforimapp.generated.resources.settings_show_home_wallpaper
 import seforimapp.seforimapp.generated.resources.settings_show_home_wallpaper_description
 import seforimapp.seforimapp.generated.resources.settings_show_zmanim_widgets
@@ -120,7 +126,63 @@ private fun DisplaySettingsView(
                 checked = state.compactMode,
                 onCheckedChange = { onEvent(DisplaySettingsEvents.SetCompactMode(it)) },
             )
+
+            MaxCommentatorsPerPageCard(
+                value = state.maxCommentatorsPerPage,
+                onValueChange = { onEvent(DisplaySettingsEvents.SetMaxCommentatorsPerPage(it)) },
+            )
         }
+    }
+}
+
+@Composable
+private fun MaxCommentatorsPerPageCard(
+    value: Int,
+    onValueChange: (Int) -> Unit,
+) {
+    val shape = RoundedCornerShape(8.dp)
+    val autoLabel = stringResource(Res.string.settings_max_commentators_per_page_auto)
+    // Index 0 = automatic (value 0); index n = value n.
+    val options =
+        remember(autoLabel) {
+            buildList {
+                add(autoLabel)
+                for (n in 1..AppSettings.MAX_COMMENTATORS_PER_PAGE_LIMIT) add(n.toString())
+            }
+        }
+    val selectedIndex = value.coerceIn(0, AppSettings.MAX_COMMENTATORS_PER_PAGE_LIMIT)
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(shape)
+                .border(1.dp, JewelTheme.globalColors.borders.normal, shape)
+                .background(JewelTheme.globalColors.panelBackground)
+                .padding(12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = stringResource(Res.string.settings_max_commentators_per_page),
+                modifier = Modifier.weight(1f),
+            )
+            ListComboBox(
+                items = options,
+                selectedIndex = selectedIndex,
+                onSelectedItemChange = { idx -> onValueChange(idx) },
+                modifier = Modifier.width(140.dp),
+            )
+        }
+        Text(
+            text = stringResource(Res.string.settings_max_commentators_per_page_description),
+            fontSize = 12.sp,
+            color = JewelTheme.globalColors.text.info,
+        )
     }
 }
 

--- a/SeforimApp/src/jvmTest/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsGridLayoutTest.kt
+++ b/SeforimApp/src/jvmTest/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsGridLayoutTest.kt
@@ -85,6 +85,47 @@ class LineCommentsGridLayoutTest {
         assertEquals(2, c.rows)
     }
 
+    // ==================== Grid capacity: user max-per-page ceiling ====================
+
+    @Test
+    fun `user cap lowers capacity below the fit-based count`() {
+        // Pane fits 2x2 = 4, but the user caps at 2 → one row of 2, rest spills to extra pages.
+        val c = computeCommentariesGridCapacity(paneWidthDp = 800f, paneHeightDp = 600f, commentTextSize = 14f, maxPerPage = 2)
+        assertEquals(2, c.perPage)
+        assertEquals(2, c.cols)
+        assertEquals(1, c.rows)
+    }
+
+    @Test
+    fun `user cap never raises capacity when the pane only fits fewer`() {
+        // Narrow pane fits a single cell; a higher cap must not force a second one.
+        val c = computeCommentariesGridCapacity(paneWidthDp = 300f, paneHeightDp = 200f, commentTextSize = 14f, maxPerPage = 3)
+        assertEquals(1, c.perPage)
+        assertEquals(1, c.cols)
+    }
+
+    @Test
+    fun `cap of one shows a single commentator per page`() {
+        val c = computeCommentariesGridCapacity(paneWidthDp = 1200f, paneHeightDp = 600f, commentTextSize = 14f, maxPerPage = 1)
+        assertEquals(1, c.perPage)
+        assertEquals(1, c.cols)
+    }
+
+    @Test
+    fun `zero cap means automatic (no ceiling)`() {
+        val auto = computeCommentariesGridCapacity(paneWidthDp = 800f, paneHeightDp = 600f, commentTextSize = 14f, maxPerPage = 0)
+        val none = computeCommentariesGridCapacity(paneWidthDp = 800f, paneHeightDp = 600f, commentTextSize = 14f)
+        assertEquals(none, auto)
+        assertEquals(4, auto.perPage)
+    }
+
+    @Test
+    fun `cap at or above the fit-based count is a no-op`() {
+        val ref = computeCommentariesGridCapacity(paneWidthDp = 800f, paneHeightDp = 600f, commentTextSize = 14f)
+        val capped = computeCommentariesGridCapacity(paneWidthDp = 800f, paneHeightDp = 600f, commentTextSize = 14f, maxPerPage = 4)
+        assertEquals(ref, capped)
+    }
+
     // ==================== Page layout: partial-page rebalancing ====================
 
     @Test


### PR DESCRIPTION
## Summary
Adds a user setting to cap how many commentators are displayed per commentaries page.

The value is a **ceiling** on the space-derived grid capacity, not a forced count:
- Room for 3 but cap = 2 → shows 2, the rest spills onto a new pager page.
- Room for only 1 → shows 1, even when the cap is higher.
- `0` = automatic (fit to available space, current behaviour).

## Changes
- `AppSettings`: persisted `max_commentators_per_page` (0 = auto, limit 6) with clamped getter/setter + `StateFlow`.
- `computeCommentariesGridCapacity`: applies the ceiling, shrinking `cols`/`rows` to keep the page layout consistent.
- Threads the value through `CommentariesLayoutConfig` → grid scaffold.
- Display settings: new `ListComboBox` (Auto, 1…6) wired through `DisplaySettings` state/events/view-model.

## Test plan
- New unit tests in `LineCommentsGridLayoutTest` cover the cap (lowers capacity, never raises, cap of 1, auto = no-op).
- `./gradlew :SeforimApp:jvmTest` green; `ktlintCheck` clean.