### PR TITLE
fix(commentaries): improve pager dot contrast in light mode

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/CommentatorsGrid.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/CommentatorsGrid.kt
@@ -346,7 +346,9 @@ private fun VerticalPagerIndicator(
     pageCount: Int,
 ) {
     val activeColor = JewelTheme.globalColors.text.normal
-    val inactiveColor = JewelTheme.globalColors.borders.normal
+    // A muted-but-readable dot: the border color is nearly invisible in light mode, so use a
+    // semi-transparent text color that keeps enough contrast against the panel in both themes.
+    val inactiveColor = JewelTheme.globalColors.text.normal.copy(alpha = 0.4f)
     val scope = rememberCoroutineScope()
     Column(
         modifier = Modifier.fillMaxHeight().width(20.dp),


### PR DESCRIPTION
## Summary
The inactive commentaries pager dots used `borders.normal`, which is nearly invisible on a light panel. They now use a semi-transparent text color (`text.normal` at 40% alpha), keeping them readable in both light and dark themes while staying clearly subordinate to the (opaque, larger) active dot.