### PR TITLE
fix(packaging): set package description for desktop distributions

### DIFF
--- a/SeforimApp/build.gradle.kts
+++ b/SeforimApp/build.gradle.kts
@@ -256,6 +256,7 @@ nucleus.application {
     nativeDistributions {
         appName = "זית"
         packageName = "zayit"
+        description = "ספריית הלימוד שמובילה ישר לטקסט"
 
         publish {
             github {


### PR DESCRIPTION
## Summary
Sets the `description` field in `nativeDistributions` so the generated `.desktop` file's `Comment=` (shown as the app subtitle in KDE's start menu) uses the app tagline instead of jpackage's default "A package distribution for desktop". Also applies to DEB/RPM package descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)