### PR TITLE
feat(settings): raise maximum text size to 50sp

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/settings/AppSettings.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/settings/AppSettings.kt
@@ -19,7 +19,7 @@ object AppSettings {
     // Text size constants
     const val DEFAULT_TEXT_SIZE = 16f
     const val MIN_TEXT_SIZE = 14f
-    const val MAX_TEXT_SIZE = 32f
+    const val MAX_TEXT_SIZE = 50f
     const val TEXT_SIZE_INCREMENT = 2f
 
     // Line height constants

--- a/SeforimApp/src/jvmTest/kotlin/io/github/kdroidfilter/seforimapp/core/settings/AppSettingsConstantsTest.kt
+++ b/SeforimApp/src/jvmTest/kotlin/io/github/kdroidfilter/seforimapp/core/settings/AppSettingsConstantsTest.kt
@@ -16,8 +16,8 @@ class AppSettingsConstantsTest {
     }
 
     @Test
-    fun `MAX_TEXT_SIZE is 32`() {
-        assertEquals(32f, AppSettings.MAX_TEXT_SIZE)
+    fun `MAX_TEXT_SIZE is 50`() {
+        assertEquals(50f, AppSettings.MAX_TEXT_SIZE)
     }
 
     @Test


### PR DESCRIPTION
Extends `MAX_TEXT_SIZE` from 32f to 50f so users can scale text larger, adding several extra zoom steps (consistent with the existing 2f increment). The constants test is updated accordingly.

All other zoom paths (keyboard shortcuts, zoom buttons, pointer zoom) already rely on the `MAX_TEXT_SIZE` constant, so they pick up the new limit automatically.