### PR TITLE
fix(bookcontent): scale alt headings with the selected text size

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BookContentView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/BookContentView.kt
@@ -974,6 +974,7 @@ fun BookContentView(
                                         level = entry.level,
                                         text = entry.text,
                                         onClick = { onLineSelect(line, false) },
+                                        baseTextSize = textSize,
                                     )
                                 }
                             }
@@ -1004,6 +1005,7 @@ fun BookContentView(
                                                 level = entry.level,
                                                 text = entry.text,
                                                 onClick = { onLineSelect(line, false) },
+                                                baseTextSize = textSize,
                                             )
                                         }
                                     }
@@ -1266,12 +1268,13 @@ private fun AltHeadingItem(
     level: Int,
     text: String,
     onClick: () -> Unit,
+    baseTextSize: Float = 16f,
 ) {
     val fontSize =
         when (level) {
-            0 -> 20.sp
-            1 -> 18.sp
-            else -> 16.sp
+            0 -> (baseTextSize * 1.25f).sp
+            1 -> (baseTextSize * 1.125f).sp
+            else -> baseTextSize.sp
         }
     val paddingTop = if (level == 0) 4.dp else 0.dp
     val paddingBottom = 4.dp


### PR DESCRIPTION
`AltHeadingItem` used hardcoded font sizes (20/18/16sp depending on level), so the alternate TOC headings rendered in the book content did not follow the user's chosen text size (keyboard, zoom buttons, pointer zoom).

This makes the heading size relative to the base text size (×1.25 / ×1.125 / ×1.0). At the default 16sp the rendered values are unchanged (20/18/16), but they now scale with the rest of the content.