### PR TITLE
chore(lint): fix pre-existing ktlint violations

### DIFF
--- a/SeforimApp/build.gradle.kts
+++ b/SeforimApp/build.gradle.kts
@@ -300,7 +300,7 @@ nucleus.application {
             TargetFormat.Dmg,
             TargetFormat.Zip,
             TargetFormat.Nsis,
-            TargetFormat.Pacman
+            TargetFormat.Pacman,
         )
         vendor = "KDroidFilter"
         cleanupNativeLibs = true

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/CommentatorsGrid.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/CommentatorsGrid.kt
@@ -348,7 +348,9 @@ private fun VerticalPagerIndicator(
     val activeColor = JewelTheme.globalColors.text.normal
     // A muted-but-readable dot: the border color is nearly invisible in light mode, so use a
     // semi-transparent text color that keeps enough contrast against the panel in both themes.
-    val inactiveColor = JewelTheme.globalColors.text.normal.copy(alpha = 0.4f)
+    val inactiveColor =
+        JewelTheme.globalColors.text.normal
+            .copy(alpha = 0.4f)
     val scope = rememberCoroutineScope()
     Column(
         modifier = Modifier.fillMaxHeight().width(20.dp),


### PR DESCRIPTION
Fixes two pre-existing ktlint violations that were blocking `./gradlew ktlintCheck`:

- `build.gradle.kts`: missing trailing comma in the `nativeDistributions` target formats list.
- `CommentatorsGrid.kt`: `chain-method-continuation` — the chained `.copy(alpha = ...)` call is now wrapped onto its own line (applied by `ktlintFormat`).

`ktlintCheck` and `detekt` both pass after these changes.