### PR TITLE
fix(tabs): show only the query in search tab titles

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/core/presentation/tabs/TabsView.kt
@@ -168,11 +168,6 @@ private fun DefaultTabShowcase(
                                     val label =
                                         when {
                                             tabItem.title.isEmpty() -> stringResource(Res.string.home_tab_with_app, appTitle)
-                                            tabItem.tabType == TabType.SEARCH ->
-                                                stringResource(
-                                                    Res.string.search_results_tab_title,
-                                                    tabItem.title,
-                                                )
                                             else -> tabItem.title
                                         }
 
@@ -190,7 +185,6 @@ private fun DefaultTabShowcase(
                             val appTitle = stringResource(Res.string.app_name)
                             when {
                                 tabItem.title.isEmpty() -> stringResource(Res.string.home_tab_with_app, appTitle)
-                                tabItem.tabType == TabType.SEARCH -> stringResource(Res.string.search_results_tab_title, tabItem.title)
                                 else -> tabItem.title
                             }
                         }
@@ -238,11 +232,6 @@ private fun DefaultTabShowcase(
                                     val label =
                                         when {
                                             tabItem.title.isEmpty() -> stringResource(Res.string.home_tab_with_app, appTitle)
-                                            tabItem.tabType == TabType.SEARCH ->
-                                                stringResource(
-                                                    Res.string.search_results_tab_title,
-                                                    tabItem.title,
-                                                )
                                             else -> tabItem.title
                                         }
 
@@ -260,7 +249,6 @@ private fun DefaultTabShowcase(
                             val appTitle = stringResource(Res.string.app_name)
                             when {
                                 tabItem.title.isEmpty() -> stringResource(Res.string.home_tab_with_app, appTitle)
-                                tabItem.tabType == TabType.SEARCH -> stringResource(Res.string.search_results_tab_title, tabItem.title)
                                 else -> tabItem.title
                             }
                         }


### PR DESCRIPTION
## Summary
- Removes the `תוצאות חיפוש : ` (Search results :) prefix from search tabs so the searched text is visible directly in the tab label.
- Behavior is now consistent with book tabs, which already show just the book name.
- Window title, dock menu and jump-list entries keep the descriptive prefix (out of scope for the tab issue).

Closes #485

## Test plan
- [ ] Run a search; confirm the tab title shows only the query text.
- [ ] Open a book; confirm the book tab still shows the book name.
- [ ] Confirm the home tab still shows "דף הבית - <app>".