### PR TITLE
fix(home): show book autocomplete popup only for the selected tab

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/HomeView.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import dev.zacsweers.metrox.viewmodel.metroViewModel
 import io.github.kdroidfilter.seforimapp.core.presentation.components.CustomToggleableChip
+import io.github.kdroidfilter.seforimapp.core.presentation.tabs.LocalTabSelected
 import io.github.kdroidfilter.seforimapp.core.presentation.theme.AccentColor
 import io.github.kdroidfilter.seforimapp.core.presentation.utils.LocalWindowViewModelStoreOwner
 import io.github.kdroidfilter.seforimapp.core.settings.AppSettings
@@ -1236,6 +1237,11 @@ private fun SearchBar(
     isTocLoading: Boolean = false,
 ) {
     val isReference = selectedFilter == SearchFilter.REFERENCE
+    // Suggestion state is shared across all tabs via the single SearchHomeViewModel, but every
+    // open tab stays composed. A Popup renders in its own window and escapes the layout(0,0) trick
+    // used to hide non-selected tabs, so without this guard each composed tab would draw a
+    // duplicate suggestions popup. Only the selected tab is allowed to show the overlay.
+    val isTabSelected = LocalTabSelected.current
     val scope = rememberCoroutineScope()
     // Hints from string resources
     val referenceHints =
@@ -1635,6 +1641,7 @@ private fun SearchBar(
         val a = anchor
         val showOverlay =
             isReference &&
+                isTabSelected &&
                 popupVisible &&
                 a != null &&
                 (


### PR DESCRIPTION
## Summary

Fixes a duplicate book-autocompletion popup on the Home page (reported as the "כפול" / double popup).

Root cause:
- The suggestion state is owned by a single shared `SearchHomeViewModel`, but every open tab stays composed permanently (non-selected tabs are measured with `layout(0, 0) {}` so they draw nothing).
- A `Popup` renders in its own window and escapes that `layout(0, 0)` trick. So whenever `suggestionsVisible = true`, every composed tab whose `SearchBar` is in reference mode drew its own popup window → two identical popups overlapping at different anchors.

Fix:
- Gate the suggestions overlay in `SearchBar` on `LocalTabSelected.current`, so only the currently selected tab renders the popup. Reuses the existing `LocalTabSelected` composition local already used elsewhere for per-tab gating.

## Test plan

- [ ] Open two Home tabs, type a book query in one → only one popup appears
- [ ] Switch tabs while the popup is open → popup follows the active tab, no duplicate
- [ ] Single Home tab still shows suggestions and book/category/TOC picking works as before