### PR TITLE
fix(bookcontent): open commentary at the currently displayed line

### DIFF
--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/BookContentEvent.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/BookContentEvent.kt
@@ -96,9 +96,14 @@ sealed interface BookContentEvent {
         val bookId: Long,
     ) : BookContentEvent
 
-    // Open a book by its id in a new tab (VM resolves Book)
+    // Open a book by its id in a new tab (VM resolves Book).
+    // When [baseLineIds] is non-empty, the book is a commentator opened from the
+    // commentaries pane: the VM positions the new tab at the line this commentator links to
+    // for those base lines (e.g. clicking "רשב״א" on Eruvin 33 opens the Rashba at daf 33),
+    // falling back to the beginning of the book when no link is found.
     data class OpenBookByIdInNewTab(
         val bookId: Long,
+        val baseLineIds: List<Long> = emptyList(),
     ) : BookContentEvent
 
     data object ToggleCommentaries : BookContentEvent

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/BookContentViewModel.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/BookContentViewModel.kt
@@ -445,9 +445,21 @@ class BookContentViewModel(
                 }
 
                 is BookContentEvent.OpenBookByIdInNewTab -> {
-                    val book = repository.getBookCore(event.bookId)
-                    if (book != null) {
-                        openBookInNewTab(book)
+                    // Opened from the commentaries pane: jump to the line this commentator links
+                    // to for the displayed base lines, falling back to the book's start.
+                    val targetLineId =
+                        if (event.baseLineIds.isNotEmpty()) {
+                            commentariesUseCase.resolveCommentaryTargetLine(event.baseLineIds, event.bookId)
+                        } else {
+                            null
+                        }
+                    if (targetLineId != null) {
+                        openCommentaryTarget(event.bookId, targetLineId)
+                    } else {
+                        val book = repository.getBookCore(event.bookId)
+                        if (book != null) {
+                            openBookInNewTab(book)
+                        }
                     }
                 }
 

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/ui/panels/bookcontent/views/LineCommentsView.kt
@@ -512,6 +512,7 @@ private fun CommentariesDisplay(
         rememberCommentariesLayoutConfig(
             selectedCommentators = selectedCommentators,
             titleToIdMap = titleToIdMap,
+            selection = selection,
             textSizes = textSizes,
             findQueryText = findQueryText,
             showDiacritics = showDiacritics,
@@ -1182,6 +1183,7 @@ internal data class CommentariesLayoutConfig(
 private fun rememberCommentariesLayoutConfig(
     selectedCommentators: ImmutableList<String>,
     titleToIdMap: Map<String, Long>,
+    selection: LineSelection,
     textSizes: AnimatedTextSizes,
     findQueryText: String,
     showDiacritics: Boolean,
@@ -1200,6 +1202,7 @@ private fun rememberCommentariesLayoutConfig(
     return remember(
         selectedCommentators,
         titleToIdMap,
+        selection,
         textSizes,
         commentaryFontFamily,
         boldScaleForPlatform,
@@ -1222,7 +1225,12 @@ private fun rememberCommentariesLayoutConfig(
                 }
             },
             onOpenCommentatorBook = { bookId ->
-                onEvent(BookContentEvent.OpenBookByIdInNewTab(bookId))
+                val baseLineIds =
+                    when (selection) {
+                        is LineSelection.Single -> listOf(selection.lineId)
+                        is LineSelection.Multi -> selection.lineIds
+                    }
+                onEvent(BookContentEvent.OpenBookByIdInNewTab(bookId, baseLineIds))
             },
             textSizes = textSizes,
             fontFamily = commentaryFontFamily,

--- a/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/usecases/CommentariesUseCase.kt
+++ b/SeforimApp/src/jvmMain/kotlin/io/github/kdroidfilter/seforimapp/features/bookcontent/usecases/CommentariesUseCase.kt
@@ -141,6 +141,41 @@ class CommentariesUseCase(
     }
 
     /**
+     * Resolves the line in the commentator's book to open when the user clicks its header in
+     * the commentaries pane. Returns the [Link.targetLineId] of the first commentary entry
+     * shown for [commentatorId] across the currently displayed base [lineIds] — i.e. the exact
+     * position currently on screen — so the book opens there rather than at its very beginning.
+     * Reuses the same paging sources the grid renders so the ordering matches the UI. Returns
+     * null when the commentator has no commentary on those lines.
+     */
+    suspend fun resolveCommentaryTargetLine(
+        lineIds: List<Long>,
+        commentatorId: Long,
+    ): Long? =
+        runSuspendCatching {
+            if (lineIds.isEmpty()) return@runSuspendCatching null
+            val source =
+                if (lineIds.size == 1) {
+                    CommentsForLineOrTocPagingSource(repository, lineIds.first(), setOf(commentatorId))
+                } else {
+                    MultiLineCommentsPagingSource(repository, lineIds, setOf(commentatorId))
+                }
+            val result =
+                source.load(
+                    PagingSource.LoadParams.Refresh(
+                        key = 0,
+                        loadSize = PagingDefaults.COMMENTS.INITIAL_LOAD_SIZE,
+                        placeholdersEnabled = false,
+                    ),
+                )
+            (result as? PagingSource.LoadResult.Page)
+                ?.data
+                ?.firstOrNull()
+                ?.link
+                ?.targetLineId
+        }.getOrNull()
+
+    /**
      * Construit un Pager pour les liens/targum d'une ligne
      */
     fun buildLinksPager(


### PR DESCRIPTION
## Summary
- Clicking a commentator's header in the commentaries pane now opens its book **at the line it links to for the currently displayed base line(s)** — e.g. while on Eruvin 33b, clicking רשב״א opens the Rashba at daf 33 — instead of at the book's beginning.
- The target line is resolved in the VM via a new `CommentariesUseCase.resolveCommentaryTargetLine`, reusing the same paging sources the grid renders so the position matches what is on screen.
- Falls back to opening the book at its start when the commentator has no commentary on those lines.
- Threaded the current `LineSelection` into the commentaries layout config so the header click carries the base line ids; extended the existing `OpenBookByIdInNewTab` event with optional `baseLineIds` (no new event type).

Closes #490

## Test plan
- [ ] Open a Gemara daf (e.g. Eruvin 33b), select a line, open the commentaries pane.
- [ ] Click a commentator header (e.g. רשב״א) → new tab opens at the corresponding daf/line, not page 1.
- [ ] Click a commentator that has no link on the current line → book opens at its beginning (fallback).
- [ ] Verify behavior in both single-line and multi-line (Ctrl+click) selection.